### PR TITLE
Add a option for null values to be accepted in validations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Patches and Suggestions
 
 - Martijn Vermaat 
 - Harro van der Klauw
+- Kaleb Pomeroy

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -124,7 +124,7 @@ class Validator(object):
             raise ValidationError(errors.ERROR_DOCUMENT_FORMAT % str(document))
         self.document = document
 
-        special_rules = ["required"]
+        special_rules = ["required", "nullable"]
         for field, value in self.document.items():
 
             if self.ignore_none_values and value is None:
@@ -133,6 +133,10 @@ class Validator(object):
             definition = self.schema.get(field)
             if definition:
                 if isinstance(definition, dict):
+
+                    if definition.get("nullable", False) == True and value is None:
+                        continue
+                        
                     definition_rules = [rule for rule in definition.keys()
                                         if rule not in special_rules]
                     for rule in definition_rules:

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -13,6 +13,10 @@ class TestBase(unittest.TestCase):
                 'maxlength': 10,
                 'required': True,
             },
+            'a_nullable_integer': {
+                'type': 'integer',
+                'nullable': True
+            },
             'an_integer': {
                 'type': 'integer',
                 'min': 1,

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -55,6 +55,12 @@ class TestValidator(TestBase):
         self.assertFail({'an_integer': 1})
         self.assertError(errors.ERROR_REQUIRED_FIELD % 'a_required_string')
 
+    def test_nullable_field_field(self):
+        self.assertSuccess({'a_nullable_integer': None})
+        self.assertSuccess({'a_nullable_integer': 3})
+        self.assertFail({'a_nullable_integer': "foo"})
+        self.assertFail({'an_integer': None})
+
     def test_readonly_field(self):
         field = 'a_readonly_string'
         self.assertFail({field: 'update me if you can'})


### PR DESCRIPTION
This change allows for a single field to be null (in addition to
its other types). This is different than required in that you
can actively change a value to None instead of omitting or
ignoring it. It is essentially the ignore_none_values, allowing
for more fine grained control down to the field level.
