### PR TITLE
Allowed validator for integer type

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -281,6 +281,9 @@ class Validator(object):
             if disallowed:
                 self._error(field,
                             errors.ERROR_UNALLOWED_VALUES % list(disallowed))
+        elif isinstance(value, int):
+            if value not in allowed_values:
+                self._error(field, errors.ERROR_UNALLOWED_VALUE % value)
 
     def _validate_empty(self, empty, field, value):
         if isinstance(value, _str_type) and len(value) == 0 and not empty:

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -22,6 +22,10 @@ class TestBase(unittest.TestCase):
                 'min': 1,
                 'max': 100,
             },
+            'a_restricted_integer': {
+                'type': 'integer',
+                'allowed': [-1, 0, 1],
+            },
             'a_boolean': {
                 'type': 'boolean',
             },

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -191,6 +191,15 @@ class TestValidator(TestBase):
         self.assertFail({field: value})
         self.assertError(field, errors.ERROR_UNALLOWED_VALUE % value)
 
+    def test_integer_unallowed(self):
+        field = 'a_restricted_integer'
+        value = 2
+        self.assertFail({field: value})
+        self.assertError(field, errors.ERROR_UNALLOWED_VALUE % value)
+
+    def test_integer_allowed(self):
+        self.assertSuccess({'a_restricted_integer': -1})
+
     def test_validate_update(self):
         self.assertTrue(self.validator.validate({'an_integer': 100},
                                                 update=True))


### PR DESCRIPTION
Now only strings and lists can have `allowed` key.
Without opening documentation, I expected the same behavior for integer type:

``` python
from cerberus import Validator

assert False == Validator({'a': {'type': 'integer', 'allowed': [-1, 0, 1]}}).validate({'a': 2})
```

So here is naive patch to extend allowed validator for integers.
