### PR TITLE
Fix non-blocking problem introduced with 0.4.1

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -167,7 +167,7 @@ class Validator(object):
 
                     if 'type' in definition:
                         self._validate_type(definition['type'], field, value)
-                        if self.errors:
+                        if self.errors.get(field):
                             continue
 
                     definition_rules = [rule for rule in definition.keys()


### PR DESCRIPTION
It stopped the checking for the entiry document if an error had occured earlier, so i fixed it, it will just stop to check the field if an error for the field already occured.
