### PR TITLE
Allow any object as document

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Patches and Suggestions
 - Arsh Singh
 - Danielle Pizzolli
 - Eelke Hermens
+- Esteban J. G. Gabancho

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -147,7 +147,7 @@ class Validator(object):
 
         if document is None:
             raise ValidationError(errors.ERROR_DOCUMENT_MISSING)
-        if not isinstance(document, dict):
+        if not hasattr(document, 'items'):
             raise ValidationError(errors.ERROR_DOCUMENT_FORMAT % str(document))
         self.document = document
 

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -308,6 +308,20 @@ class TestValidator(TestBase):
         self.assertFalse(v.validate({'test_field': 6}))
         self.assertError('test_field', 'Not an odd number', validator=v)
 
+    def test_custon_document(self):
+        class MyDocument(object):
+            def __init__(self, d):
+                self.__dict = d
+            def get(self, k, d=None):
+                return self.__dict.get(k, d)
+            def items(self):
+                return self.__dict.items()
+            def keys(self):
+                return self.__dict.keys()
+        schema = {'name': {'type': 'string'}}
+        document = MyDocument({'name': 'john doe'})
+        self.assertSuccess(document, schema)
+
     def test_transparent_schema_rules(self):
         field = 'test'
         schema = {field: {'type': 'string', 'unknown_rule': 'a value'}}


### PR DESCRIPTION
- Allow any kind of python object that implements the dictionary
  interface as document.
