### PR TITLE
Successfully validate int as float type

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -309,7 +309,7 @@ class Validator(object):
             self._error(field, errors.ERROR_BAD_TYPE % "integer")
 
     def _validate_type_float(self, field, value):
-        if not isinstance(value, float):
+        if not isinstance(value, float) and not isinstance(value, _int_types):
             self._error(field, errors.ERROR_BAD_TYPE % "float")
 
     def _validate_type_number(self, field, value):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -270,6 +270,7 @@ class TestValidator(TestBase):
 
     def test_float(self):
         self.assertSuccess({'a_float': 3.5})
+        self.assertSuccess({'a_float': 1})
 
     def test_number(self):
         self.assertSuccess({'a_number': 3.5})


### PR DESCRIPTION
An integer can be used where a float is required since it is implicitly upcast
if needed. This is particularly relevant for data that originates from parsing
a string (e.g. JSON), where a number with no decimal places will be
represented as an integer.
