### PR TITLE
Allow native types

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -256,6 +256,10 @@ class Validator(object):
                 raise SchemaError(errors.ERROR_DEFINITION_FORMAT % field)
             for constraint, value in constraints.items():
                 if constraint == 'type':
+                    # Check if an object type is passed in
+                    if isinstance(value, type):
+                        value = value.__name__
+
                     if not hasattr(self, '_validate_type_' + value):
                         raise SchemaError(
                             errors.ERROR_UNKNOWN_TYPE % value)
@@ -275,8 +279,8 @@ class Validator(object):
                             self.validate_schema({'schema': item_schema})
                 elif not hasattr(self, '_validate_' + constraint):
                     if not self.transparent_schema_rules:
-                            raise SchemaError(errors.ERROR_UNKNOWN_RULE % (
-                                constraint, field))
+                        raise SchemaError(errors.ERROR_UNKNOWN_RULE % (
+                            constraint, field))
 
     def _validate_required_fields(self, document):
         required = list(field for field, definition in self.schema.items()
@@ -307,6 +311,12 @@ class Validator(object):
         if not isinstance(value, _str_type):
             self._error(field, errors.ERROR_BAD_TYPE % "string")
 
+    def _validate_type_int(self, field, value):
+        """
+        .. versionadded:: 0.7.3
+        """
+        self._validate_type_integer(field, value)
+
     def _validate_type_integer(self, field, value):
         if not isinstance(value, _int_types):
             self._error(field, errors.ERROR_BAD_TYPE % "integer")
@@ -321,6 +331,12 @@ class Validator(object):
         """
         if not isinstance(value, float) and not isinstance(value, _int_types):
             self._error(field, errors.ERROR_BAD_TYPE % "number")
+
+    def _validate_type_bool(self, field, value):
+        """
+        .. versionadded:: 0.7.3
+        """
+        self._validate_type_boolean(field, value)
 
     def _validate_type_boolean(self, field, value):
         if not isinstance(value, bool):

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -22,6 +22,11 @@ class TestBase(unittest.TestCase):
                 'min': 1,
                 'max': 100,
             },
+            'an_integer_native': {
+                'type': int,
+                'min': 1,
+                'max': 100,
+            },
             'a_restricted_integer': {
                 'type': 'integer',
                 'allowed': [-1, 0, 1],
@@ -29,11 +34,19 @@ class TestBase(unittest.TestCase):
             'a_boolean': {
                 'type': 'boolean',
             },
+            'a_boolean_native': {
+                'type': bool,
+            },
             'a_datetime': {
                 'type': 'datetime',
             },
             'a_float': {
                 'type': 'float',
+                'min': 1,
+                'max': 100,
+            },
+            'a_float_native': {
+                'type': float,
                 'min': 1,
                 'max': 100,
             },


### PR DESCRIPTION
Support using the native types directly instead of passing it in as strings (https://docs.python.org/library/types.html).

Builds on already existing functionality and provides a few simple wrapper functions around types that used the longer names (`int` -> `integer`, `bool` -> `boolean`). This takes the schema validation somewhat in the direction of how `argparse` type validation is done.
