### PR TITLE
Add travis_retry to pip install in case of network issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ env:
   - TOX_ENV=py33
   - TOX_ENV=py34
   - TOX_ENV=flake8
-install: pip install tox
+install: travis_retry pip install tox
 script: 
   - tox -e $TOX_ENV


### PR DESCRIPTION
This will retry pip install 3 times if there are any network failures. I had a problem with one of my other PRs where the connection was reset and failed one of the build units instead of retrying https://travis-ci.org/nicolaiarocci/cerberus/jobs/28534465
