### PR TITLE
Fix dependency is not considered satisfied if it has a null value.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,3 +48,4 @@ Patches and Suggestions
 - Waldir Pimenta
 - calve
 - gilbsgilbs
+- davidt99

--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Not released yet.
   a KeyError. Closes #302 (Frank Sachsenheim)
 - Fix: Error when setting fields as tuples instead of lists. Closes #271
   (Sebastian Rajo).
+- Fix: Dependency was not considered satisfied if it has a null value. Closes #305.
 
 Version 1.1
 -----------

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -808,6 +808,30 @@ def test_dependencies_dict_with_required_field():
     assert_success({'foo': 'bar', 'bar': 'foo'}, schema)
 
 
+def test_dependencies_field_satisfy_nullable_field():
+    # https://github.com/pyeve/cerberus/issues/305
+    schema = {
+        'foo': {'required': False, 'nullable': True},
+        'bar': {'required': False, 'dependencies': 'foo'}
+    }
+
+    assert_success({'foo': None, 'bar': 1}, schema)
+    assert_success({'foo': None}, schema)
+    assert_fail({'bar': 1}, schema)
+
+
+def test_dependencies_field_with_mutually_dependent_nullable_fields():
+    schema = {
+        'foo': {'required': False, 'dependencies': 'bar', 'nullable': True},
+        'bar': {'required': False, 'dependencies': 'foo', 'nullable': True}
+    }
+    assert_success({'foo': None, 'bar': None}, schema)
+    assert_success({'foo': 1, 'bar': 1}, schema)
+    assert_success({'foo': None, 'bar': 1}, schema)
+    assert_fail({'foo': None}, schema)
+    assert_fail({'foo': 1}, schema)
+
+
 def test_dependencies_dict_with_subodcuments_fields():
     schema = {
         'test_field': {'dependencies': {'a_dict.foo': ['foo', 'bar'],

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -93,7 +93,7 @@ class Validator(object):
     """ Rules that are evaluated on any field, regardless whether defined in
         the schema or not.
         Type: :class:`tuple` """
-    priority_validations = ('nullable', 'readonly', 'type')
+    priority_validations = ('dependencies', 'nullable', 'readonly', 'type')
     """ Rules that will be processed in that order before any other and abort
         validation of a document's field if return ``True``.
         Type: :class:`tuple` """
@@ -347,9 +347,9 @@ class Validator(object):
 
         parts = path.split('.')
         for part in parts:
-            context = context.get(part)
-            if context is None:
+            if part not in context:
                 return None, None
+            context = context[part]
 
         return parts[-1], context
 
@@ -898,10 +898,6 @@ class Validator(object):
             self.__validate_dependencies_sequence(dependencies, field)
         elif isinstance(dependencies, Mapping):
             self.__validate_dependencies_mapping(dependencies, field)
-
-        if self.document_error_tree.fetch_node_from(
-                self.schema_path + (field, 'dependencies')) is not None:
-            return True
 
     def __validate_dependencies_mapping(self, dependencies, field):
         validated_dependencies_counter = 0


### PR DESCRIPTION
Closes #305 
It's also solves a case when a field is nullable and `none`, the dependencies requirements is ignored.
I'm not very happy with the solution but I don't that familiar with the code base.