### PR TITLE
Fixes the lookup for dependency fields.

### DIFF
--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -808,7 +808,19 @@ def test_dependencies_dict_with_required_field():
     assert_success({'foo': 'bar', 'bar': 'foo'}, schema)
 
 
-def test_dependencies_dict_with_subodcuments_fields():
+def test_dependencies_field_satisfy_nullable_field():
+    # https://github.com/pyeve/cerberus/issues/305
+    schema = {
+        'foo': {'nullable': True},
+        'bar': {'dependencies': 'foo'}
+    }
+
+    assert_success({'foo': None, 'bar': 1}, schema)
+    assert_success({'foo': None}, schema)
+    assert_fail({'bar': 1}, schema)
+
+
+def test_dependencies_dict_with_subdocuments_fields():
     schema = {
         'test_field': {'dependencies': {'a_dict.foo': ['foo', 'bar'],
                                         'a_dict.bar': 'bar'}},

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -240,7 +240,8 @@ class Validator(object):
             else:
                 field_definitions = self._resolve_rules_set(self.schema[field])
                 if rule == 'nullable':
-                    constraint = field_definitions.get(rule, False)
+                    constraint = field_definitions.get(rule,
+                                                       self.ignore_none_values)
                 else:
                     constraint = field_definitions[rule]
 
@@ -347,9 +348,9 @@ class Validator(object):
 
         parts = path.split('.')
         for part in parts:
-            context = context.get(part)
-            if context is None:
+            if part not in context:
                 return None, None
+            context = context.get(part)
 
         return parts[-1], context
 
@@ -842,7 +843,7 @@ class Validator(object):
         else:
             self._error(field, errors.UNKNOWN_FIELD)
 
-    # Remember to keep the validations method below this line
+    # Remember to keep the validation methods below this line
     # sorted alphabetically
 
     def __validate_definitions(self, definitions, field):
@@ -892,7 +893,7 @@ class Validator(object):
     def _validate_dependencies(self, dependencies, field, value):
         """ {'type': ['dict', 'hashable', 'hashables']} """
         if isinstance(dependencies, _str_type):
-            dependencies = [dependencies]
+            dependencies = (dependencies,)
 
         if isinstance(dependencies, Sequence):
             self.__validate_dependencies_sequence(dependencies, field)

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -355,10 +355,10 @@ Validates if *none* of the provided constraints validates the field. See `\*of-r
 
 nullable
 --------
-If ``True`` the field value can be set to :obj:`None`. It is essentially the
-functionality of the :attr:`~cerberus.Validator.ignore_none_values` property
-of a :class:`~cerberus.Validator` instance, but allowing for more fine grained
-control down to the field level.
+If ``True`` the field value is allowed to be :obj:`None`. The rule will be
+checked on every field, regardless it's defined or not. The rule's constraint
+defaults to the :attr:`~cerberus.Validator.ignore_none_values` property of a
+:class:`~cerberus.Validator` instance if not defined in the schema.
 
 .. doctest::
 


### PR DESCRIPTION
since it wasn't clear to me what parts of #306 are necessary to solve #305, i took a look at it and found that the relationship of `nullable` and `ignore_none_values` required some clarification.
the test schema is intentionally reduced from the ones @derek-miller and @davidt99 provided.

Fixes #305 and partly replaces #306.