### PR TITLE
Failing test: rules registry used in dict fields

### DIFF
--- a/cerberus/tests/test_registries.py
+++ b/cerberus/tests/test_registries.py
@@ -67,3 +67,13 @@ def test_normalization_with_rules_set():
     assert_normalized({}, {'bar': 42}, {'bar': 'foo'})
     rules_set_registry.add('foo', {'type': 'integer', 'nullable': True})
     assert_success({'bar': None}, {'bar': 'foo'})
+
+
+def test_rules_set_with_dict_field():
+    rules_set_registry.add('rule', {'type': 'integer'})
+    assert_success({'bar': 1, 'a_dict': {'foo': 1}},
+                   {'bar': 'rule', 'a_dict': {'type': 'dict', 'schema':
+                                              {'foo': {'type': 'integer'}}}})
+    assert_success({'bar': 1, 'a_dict': {'foo': 1}},
+                   {'bar': 'rule', 'a_dict': {'type': 'dict', 'schema':
+                                              {'foo': 'rule'}}})

--- a/cerberus/tests/test_schema.py
+++ b/cerberus/tests/test_schema.py
@@ -83,7 +83,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 130
+    max_cache_size = 131
     assert cache_size <= max_cache_size, \
         "There's an unexpected high amount (%s) of cached valid " \
         "definition schemas. Unless you added further tests, " \


### PR DESCRIPTION
It looks like rules added to the registry cannot be used within dict
fields. Would be nice to be able to use them in these scenarios, which
are pretty common with complex documents.