### PR TITLE
Make allow_unknown and purge_unknown work together

### DIFF
--- a/cerberus/tests/test_normalization.py
+++ b/cerberus/tests/test_normalization.py
@@ -441,3 +441,29 @@ def test_allow_unknown_wo_schema():
     # https://github.com/pyeve/cerberus/issues/302
     v = Validator({'a': {'type': 'dict', 'allow_unknown': True}})
     v({'a': {}})
+
+
+def test_allow_unknown_with_purge_unknown():
+    validator = Validator(purge_unknown=True)
+    schema = {'foo': {'type': 'dict', 'allow_unknown': True}}
+    document = {'foo': {'bar': True}, 'bar': 'foo'}
+    expected = {'foo': {'bar': True}}
+    assert_normalized(document, expected, schema, validator)
+
+
+def test_allow_unknown_with_purge_unknown_subdocument():
+    validator = Validator(purge_unknown=True)
+    schema = {
+        'foo': {
+            'type': 'dict',
+            'schema': {
+                'bar': {
+                    'type': 'string'
+                }
+            },
+            'allow_unknown': True
+        }
+    }
+    document = {'foo': {'bar': 'baz', 'corge': False}, 'thud': 'xyzzy'}
+    expected = {'foo': {'bar': 'baz', 'corge': False}}
+    assert_normalized(document, expected, schema, validator)

--- a/cerberus/tests/test_schema.py
+++ b/cerberus/tests/test_schema.py
@@ -83,7 +83,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 131
+    max_cache_size = 133
     assert cache_size <= max_cache_size, \
         "There's an unexpected high amount (%s) of cached valid " \
         "definition schemas. Unless you added further tests, " \

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -599,7 +599,7 @@ class Validator(object):
             schema[field] = self._resolve_rules_set(schema[field])
 
         self.__normalize_rename_fields(mapping, schema)
-        if self.purge_unknown:
+        if self.purge_unknown and not self.allow_unknown:
             self._normalize_purge_unknown(mapping, schema)
         # Check `readonly` fields before applying default values because
         # a field's schema definition might contain both `readonly` and

--- a/docs/normalization-rules.rst
+++ b/docs/normalization-rules.rst
@@ -48,6 +48,8 @@ After renaming, unknown fields will be purged if the
 You can set the property per keyword-argument upon initialization or as rule for
 subdocuments like ``allow_unknown`` (see :ref:`allowing-the-unknown`). The default is
 ``False``.
+If a subdocument includes an ``allow_unknown`` rule then unknown fields
+will not be purged on that subdocument.
 
 .. doctest::
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -7,7 +7,9 @@ This can be used in conjunction with the  `schema <schema_dict-rule>`_ rule
 when validating a mapping in order to set the
 :attr:`~cerberus.Validator.allow_unknown` property of the validator for the
 subdocument.
-For a full alaboration refer to :ref:`this paragraph <allowing-the-unknown>`.
+This rule has precedence over ``purge_unknown``
+(see :ref:`purging-unknown-fields`).
+For a full elaboration refer to :ref:`this paragraph <allowing-the-unknown>`.
 
 allowed
 -------


### PR DESCRIPTION
Fix  #324.
When setting 'purge_unknown' on the top-level (Validator), then all
unknown fields are removed from the document. In particular, fields that
were explicitly marked with 'allow_unknown' are also deleted.