### PR TITLE
Adding support for Decimal type (Decimal module)

### DIFF
--- a/cerberus/tests/conftest.py
+++ b/cerberus/tests/conftest.py
@@ -62,6 +62,9 @@ sample_schema = {
         'min': 1,
         'max': 100,
     },
+    'a_decimal': {
+        'type': 'decimal',
+    },
     'a_set': {
         'type': 'set',
     },

--- a/cerberus/tests/test_schema.py
+++ b/cerberus/tests/test_schema.py
@@ -83,7 +83,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 130
+    max_cache_size = 132
     assert cache_size <= max_cache_size, \
         "There's an unexpected high amount (%s) of cached valid " \
         "definition schemas. Unless you added further tests, " \

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -648,6 +648,10 @@ Data type allowed for the key value. Can be one of the following names:
    * - ``string``
      - :func:`py2:basestring`
      - :class:`py3:str`
+   * - ``decimal``
+     - :class:`py2:decimal.Decimal() (or bson.decimal128.Decimal128() if available)`
+     - :class:`py3:decimal.Decimal() (or bson.decimal128.Decimal128() if available)`
+
 
 You can extend this list and support :ref:`custom types <new-types>`.
 
@@ -690,6 +694,9 @@ A list of types can be used to allow different values:
     rules on the field will be skipped and validation will continue on other
     fields. This allows to safely assume that field type is correct when other
     (standard or custom) rules are invoked.
+
+.. versionchanged:: 1.2
+   Added the ``decimal`` data type to support decimal module.
 
 .. versionchanged:: 1.0
    Added the ``binary`` data type.

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ VERSION = __import__('cerberus').__version__
 needs_pytest = set(('pytest', 'test', 'ptr')) & set(sys.argv)
 setup_requires = ['pytest-runner'] if needs_pytest else []
 
+setup_requires.append('pymongo')
 
 setup(
     name='Cerberus',
@@ -25,7 +26,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     setup_requires=setup_requires,
-    tests_require=['pytest'],
+    tests_require=['pytest', 'pymongo'],
     test_suite="cerberus.tests",
     install_requires=[],
     keywords=['validation', 'schema', 'dictionaries'],

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist=py26,py27,py33,py34,py35,py36,pypy,pypy3,flake8,doclinks,doctest
 
 [testenv]
 deps=pytest
+     pymongo
 commands=pytest cerberus/tests
 
 [testenv:flake8]


### PR DESCRIPTION
This PR has the goal to provide support to validate decimal data type. 

This way allows checking whether the number in the request is parsable by the decimal module. Note: this is to provide support for the new decimal type in mongodb.