### PR TITLE
Refactors type validation to a descriptive paradigm

### DIFF
--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -10,9 +10,10 @@
 
 from __future__ import absolute_import
 
-from cerberus.validator import Validator, DocumentError
+from cerberus.validator import DocumentError, Validator
 from cerberus.schema import (rules_set_registry, schema_registry, Registry,
                              SchemaError)
+from cerberus.utils import TypeDefinition
 
 
 __version__ = "1.1"
@@ -21,6 +22,7 @@ __all__ = [
     DocumentError.__name__,
     Registry.__name__,
     SchemaError.__name__,
+    TypeDefinition.__name__,
     Validator.__name__,
     'schema_registry',
     'rules_set_registry'

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -12,15 +12,13 @@ from cerberus.platform import PYTHON_VERSION
 from cerberus.utils import compare_paths_lt, quote_string
 
 
-ErrorDefinition = namedtuple('cerberus_error', 'code, rule')
+ErrorDefinition = namedtuple('ErrorDefinition', 'code, rule')
 """
-Error definition class
-
-Each distinguishable error is defined as a two-value-tuple that holds
-a *unique* error id as integer and the rule as string that can cause it.
-The attributes are accessible as properties ``id`` and ``rule``.
-The names do not contain a common prefix as they are supposed to be referenced
-within the module namespace, e.g. errors.CUSTOM
+This class is used to define possible errors. Each distinguishable error is
+defined by a *unique* error ``code`` as integer and the ``rule`` that can
+cause it as string.
+The instances' names do not contain a common prefix as they are supposed to be
+referenced within the module namespace, e.g. ``errors.CUSTOM``.
 """
 
 

--- a/cerberus/tests/test_assorted.py
+++ b/cerberus/tests/test_assorted.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from decimal import Decimal
+
 from pytest import mark
 
+from cerberus import TypeDefinition, Validator
 from cerberus.tests import assert_fail, assert_success
 
 
@@ -27,3 +30,19 @@ def test_that_test_fails(test, document):
         pass
     else:
         raise AssertionError("test didn't fail")
+
+
+def test_dynamic_types():
+    decimal_type = TypeDefinition('decimal', (Decimal,), ())
+    document = {'measurement': Decimal(0)}
+    schema = {'measurement': {'type': 'decimal'}}
+
+    validator = Validator()
+    validator.types_mapping['decimal'] = decimal_type
+    assert_success(document, schema, validator)
+
+    class MyValidator(Validator):
+        types_mapping = Validator.types_mapping.copy()
+        types_mapping['decimal'] = decimal_type
+    validator = MyValidator()
+    assert_success(document, schema, validator)

--- a/cerberus/tests/test_schema.py
+++ b/cerberus/tests/test_schema.py
@@ -83,7 +83,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 130
+    max_cache_size = 131
     assert cache_size <= max_cache_size, \
         "There's an unexpected high amount (%s) of cached valid " \
         "definition schemas. Unless you added further tests, " \

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -539,6 +539,7 @@ def test_custom_datatype_rule():
             if value < min_number:
                 self._error(field, 'Below the min')
 
+        # TODO replace with TypeDefintion in next major release
         def _validate_type_number(self, value):
             if isinstance(value, int):
                 return True

--- a/cerberus/utils.py
+++ b/cerberus/utils.py
@@ -1,8 +1,21 @@
 from __future__ import absolute_import
 
-from collections import Mapping, Sequence
+from collections import Mapping, namedtuple, Sequence
 
 from cerberus.platform import _int_types, _str_type
+
+
+TypeDefinition = namedtuple('TypeDefinition',
+                            'name,included_types,excluded_types')
+"""
+This class is used to define types that can be used as value in the
+:attr:`~cerberus.Validator.types_mapping` property.
+The ``name`` should be descriptive and match the key it is going to be assigned
+to.
+A value that is validated against such definition must be an instance of any of
+the types contained in ``included_types`` and must not match any of the types
+contained in ``excluded_types``.
+"""
 
 
 def compare_paths_lt(x, y):
@@ -64,6 +77,17 @@ def quote_string(value):
         return '"%s"' % value
     else:
         return value
+
+
+class readonly_classproperty(property):
+    def __get__(self, instance, owner):
+        return super(readonly_classproperty, self).__get__(owner)
+
+    def __set__(self, instance, value):
+        raise RuntimeError('This is a readonly class property.')
+
+    def __delete__(self, instance):
+        raise RuntimeError('This is a readonly class property.')
 
 
 def validator_factory(name, mixin=None, class_dict={}):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,7 +12,8 @@ Validator Class
             priority_validations, purge_unknown, recent_error,
             _remaining_rules, root_allow_unknown, root_document, root_schema,
             rules_set_registry, schema, schema_error_tree, schema_path,
-            schema_registry, _valid_schemas, validate, validated
+            schema_registry, types, types_mapping, _valid_schemas, validate,
+            validated
 
 
 Rules Set & Schema Registry
@@ -20,6 +21,12 @@ Rules Set & Schema Registry
 
 .. autoclass:: cerberus.Registry
   :members:
+
+
+Type Definitions
+----------------
+
+.. autoclass:: cerberus.TypeDefinition
 
 
 Error Handlers
@@ -36,6 +43,8 @@ Error Handlers
 Python Error Representations
 ----------------------------
 
+.. autoclass:: cerberus.errors.ErrorDefinition
+
 .. autoclass:: cerberus.errors.ValidationError
   :members:
 
@@ -47,6 +56,9 @@ Error Codes
 These errors are used as :attr:`~cerberus.errors.ValidationError.code`.
 
 .. include:: includes/error-codes.rst
+
+Error Containers
+~~~~~~~~~~~~~~~~
 
 .. autoclass:: cerberus.errors.ErrorList
 

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -75,29 +75,44 @@ Custom Data Types
 Cerberus supports and validates several standard data types (see :ref:`type`).
 When building a custom validator you can add and validate your own data types.
 
-For example `Eve <http://python-eve.org>`_ (a tool for quickly building and
-deploying RESTful Web Services) supports a custom ``objectid`` type, which is
-used to validate that field values conform to the BSON/MongoDB ``ObjectId``
-format.
-
-You extend the supported set of data types by adding
-a ``_validate_type_<typename>`` method to your own :class:`~cerberus.Validator`
-subclass. This snippet, directly from Eve source, shows how the ``objectid``
-has been implemented:
+Additional types can be added on the fly by assigning a
+:class:`~cerberus.TypeDefinition` to the designated type name in
+:attr:`~cerberus.Validator.types_mapping`:
 
 .. testcode::
 
-     def _validate_type_objectid(self, value):
-         """ Enables validation for `objectid` schema attribute.
-         :param value: field value.
-         """
-         if re.match('[a-f0-9]{24}', value):
-             return True
+    from decimal import Decimal
+
+    decimal_type = cerberus.TypeDefinition('decimal', (Decimal,), ())
+
+    Validator.types_mapping['decimal'] = decimal_type
+
+.. caution::
+
+    As the ``types_mapping`` property is a mutable type, any change to its
+    items on an instance will affect its class.
+
+They can also be defined for subclasses of :class:`~cerberus.Validator`:
+
+.. testcode::
+
+    from decimal import Decimal
+
+    decimal_type = cerberus.TypeDefinition('decimal', (Decimal,), ())
+
+    class CustomValidator(Validator):
+        types_mapping = Validator.types_mapping.copy()
+        types_mapping['decimal'] = decimal_type
+
 
 .. versionadded:: 0.0.2
 
 .. versionchanged:: 1.0
    The type validation logic changed, see :doc:`upgrading`.
+
+.. versionchanged:: 1.2
+   Added the :attr:`~cerberus.Validator.types_mapping` property and marked
+   methods for testing types as deprecated.
 
 Custom Validators
 -----------------


### PR DESCRIPTION
this is not completed, just a proof-of-concept for a proposal.

as an aftermath of #332 i came to this approach to deal with type checks. it still supports custom 'type' testing methods (propably we all have misused them at some point), but i also propose to eventually remove this capability with the next breaking release for these reasons:

- just dealing with a mapping is obviously simpler than with methods
- it restricts to use the 'type' rule to really just test the type of an object
- and thus follows the recent development in Python to do better with types (type annotations, etc.)
- it also enforces (of course the appropriate 'vereindeutigen' seems to be a german-only term) the semantic of the 'type' rule's name

any other uses beside type checking that have been put in custom type validators can still be achieved with the 'validator' rule.

cc @Amedeo91