### PR TITLE
Skip some rules on empty fields that are allowed to be empty.

### DIFF
--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -589,6 +589,12 @@ def test_empty_values(value, _type):
     assert_success(document, schema)
 
 
+def test_empty_skips_regex(validator):
+    schema = {'foo': {'empty': True, 'regex': r'\d?\d\.\d\d',
+                      'type': 'string'}}
+    assert validator({'foo': ''}, schema)
+
+
 def test_ignore_none_values():
     field = 'test'
     schema = {field: {'type': 'string', 'empty': False, 'required': False}}

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -94,7 +94,7 @@ class Validator(object):
     """ Rules that are evaluated on any field, regardless whether defined in
         the schema or not.
         Type: :class:`tuple` """
-    priority_validations = ('nullable', 'readonly', 'type')
+    priority_validations = ('nullable', 'readonly', 'type', 'empty')
     """ Rules that will be processed in that order before any other.
         Type: :class:`tuple` """
     types_mapping = {
@@ -998,8 +998,12 @@ class Validator(object):
 
     def _validate_empty(self, empty, field, value):
         """ {'type': 'boolean'} """
-        if isinstance(value, Iterable) and len(value) == 0 and not empty:
-            self._error(field, errors.EMPTY_NOT_ALLOWED)
+        if isinstance(value, Iterable) and len(value) == 0:
+            self._drop_remaining_rules(
+                'allowed', 'forbidden', 'items', 'minlength', 'maxlength',
+                'regex', 'validator')
+            if not empty:
+                self._error(field, errors.EMPTY_NOT_ALLOWED)
 
     def _validate_excludes(self, excludes, field, value):
         """ {'type': ('hashable', 'list'),

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -209,9 +209,13 @@ special meaning.
 
 empty
 -----
-If ``False`` validation of an :term:`iterable` value will fail if it is empty.
-Setting it to ``True`` manually is pointless as it behaves like omitting the
-rule at all.
+If constrained with ``False`` validation of an :term:`iterable` value will fail
+if it is empty.
+Per default the emptiness of a field isn't checked and is therefore allowed
+when the rule isn't defined. But defining it with the constraint ``True`` will
+skip the possibly defined rules ``allowed``, ``forbidden``, ``items``,
+``minlength``, ``maxlength``, ``regex`` and ``validator`` for that field when
+the value is considered empty.
 
 .. doctest::
 


### PR DESCRIPTION
This allows a less verbose definition of schemas that allow values to be empty while havin expectations on non-empty values.

beware, this brings quiet implicit behaviour.

Closes #326.