### PR TITLE
Let's have a roadmap

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
-include README.rst
+include AUTHORS
+include CHANGES
+include CONTRIBUTING.rst
 include LICENSE
+include README.rst
+include UPGRADING.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include CHANGES
 include CONTRIBUTING.rst
 include LICENSE
 include README.rst
+include ROADMAP.md
 include UPGRADING.rst

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,7 +62,7 @@ implications.
       part where `schema` tested items in sequences so far. (#tba)
 - [ ] Implementations of rules, coercers etc. can and the contributed should be
       qualified as such by metadata-annotating decorators. (With the intend to
-      clean the code and make extensions simpler.) (#tba)
+      clean the code and make extensions simpler.) (#372)
 - [ ] Dependency injection for all kind of handlers. (#279,#314)
 - [ ] The feature freeze gets lifted and the `CONTRIBUTING.rst` is updated
       accordingly.
@@ -70,6 +70,8 @@ implications.
 #### Undecided issues
 
 - Which Python version will be the minimum to support?
+  - CPython 3.4 will be eol before 2.7 and 3.5 brings some extensions to the
+    `inspect` module that would ease implementing a dependency injection.
 - The name `itemrules`.
 - Should the result be released as 2.0.a1?
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,30 +9,31 @@ The current status is a **draft**, pull requests for changes are welcome.
 
 There are some assumptions that guide the following:
 
-- The support of CPython 2.7 will end on April 12, 2020.
+- The support of CPython 2.7 will end on January 1st, 2020.
+  (See [Python Developer’s Guide](https://devguide.python.org/#status-of-python-branches))
 - Supporting Python 2 and 3 comes with trade-offs.
 - Everything is an object.
 
 
 ## Roadmap
 
-### 1.2 release
+### 1.3 release
 
-The release is estimated to be ready at the end of 2017.
-The planned fixes and features are listed 
+The release is estimated to be ready in mid or late 2018.
+The planned fixes and features are listed
 [here](https://github.com/pyeve/cerberus/milestone/5).
 It will contain a finalized version of this document.
 
 ### Branching off 1.x
 
-After that release, a new branch `1.x` is created. It will continue to support
-Python 2 and receive bug fixes *at least* until December 31, 2019.
+After that release, a new branch `1.x` is created. This one  will continue to
+support Python 2 and receive bug fixes *at least* until December 31, 2019.
 A *feature freeze* for functionality of the public API is declared.
 
 #### Checklist
 
 - [ ] The `README.rst` and `CONTRIBUTING.rst` are updated accordingly.
-- [ ] 1.2 is released.
+- [ ] 1.3 is released.
 - [ ] 1.x branch is created.
 
 #### Undecided issues
@@ -47,20 +48,22 @@ implications.
 #### Checklist
 
 - [ ] All Python 2 related code is removed.
-- [ ] Python 3 features that allow simpler code are applied where feasible are
-      used.
+- [ ] Python 3 features that allow simpler code are applied where feasible.
   - [ ] A Python 3-style metaclass.
+  - [ ] Using `super()` to call overridden methods.
+  - [ ] Usage of dictionary comprehensions.
 - [ ] All functions and methods are type annotated. MyPy is added to the test
       suite.
 - [ ] A wider choice of type names that are closer oriented on the builtin
       names are available. (#tba)
-- [ ] Objects from the `typing` module can be used as constraints for the 
+- [ ] Objects from the `typing` module can be used as constraints for the
       `type` rule.
 - [ ] The `schema` rule only handles mappings, a new `itemrules` replaces the
-      part where `schema` tested items in sequences so far.
-- [ ] Handlers for rules, coercers etc. can and the contributed should be
+      part where `schema` tested items in sequences so far. (#tba)
+- [ ] Implementations of rules, coercers etc. can and the contributed should be
       qualified as such by metadata-annotating decorators. (With the intend to
-      clean the code and make extensions simpler.)
+      clean the code and make extensions simpler.) (#tba)
+- [ ] Dependency injection for all kind of handlers. (#279,#314)
 - [ ] The feature freeze gets lifted and the `CONTRIBUTING.rst` is updated
       accordingly.
 
@@ -78,7 +81,6 @@ available in the middle of 2018.
 #### Checklist
 
 - [ ] The `DocumentError` exception is replaced with an error. (#141)
-- [ ] Dependency injection for all kind of handlers. (#279,#314)
 - [ ] A convenient way for document processing chains and branches. (#tba)
 - [ ] Include a guide on upgrading from 1.x.
 - [ ] Remove this document.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,84 @@
+# Cerberus development and support roadmap
+
+This document lays out a roadmap for the further development of Cerberus in the
+next few years, particularly in anticipation of the decay of Python 2.
+The current status is a **draft**, pull requests for changes are welcome.
+
+
+## Assumptions
+
+There are some assumptions that guide the following:
+
+- The support of CPython 2.7 will end on April 12, 2020.
+- Supporting Python 2 and 3 comes with trade-offs.
+- Everything is an object.
+
+
+## Roadmap
+
+### 1.2 release
+
+The release is estimated to be ready at the end of 2017.
+The planned fixes and features are listed 
+[here](https://github.com/pyeve/cerberus/milestone/5).
+It will contain a finalized version of this document.
+
+### Branching off 1.x
+
+After that release, a new branch `1.x` is created. It will continue to support
+Python 2 and receive bug fixes *at least* until December 31, 2019.
+A *feature freeze* for functionality of the public API is declared.
+
+#### Checklist
+
+- [ ] The `README.rst` and `CONTRIBUTING.rst` are updated accordingly.
+- [ ] 1.2 is released.
+- [ ] 1.x branch is created.
+
+#### Undecided issues
+
+- Shall we start releasing micro / patch releases from here on?
+
+### Modernization and consolidation
+
+This phase is designated to update the codebase with fundamental
+implications.
+
+#### Checklist
+
+- [ ] All Python 2 related code is removed.
+- [ ] Python 3 features that allow simpler code are applied where feasible are
+      used.
+  - [ ] A Python 3-style metaclass.
+- [ ] All functions and methods are type annotated. MyPy is added to the test
+      suite.
+- [ ] A wider choice of type names that are closer oriented on the builtin
+      names are available. (#tba)
+- [ ] Objects from the `typing` module can be used as constraints for the 
+      `type` rule.
+- [ ] The `schema` rule only handles mappings, a new `itemrules` replaces the
+      part where `schema` tested items in sequences so far.
+- [ ] Handlers for rules, coercers etc. can and the contributed should be
+      qualified as such by metadata-annotating decorators. (With the intend to
+      clean the code and make extensions simpler.)
+- [ ] The feature freeze gets lifted and the `CONTRIBUTING.rst` is updated
+      accordingly.
+
+#### Undecided issues
+
+- Which Python version will be the minimum to support?
+- The name `itemrules`.
+- Should the result be released as 2.0.a1?
+
+### 2.0 release
+
+After a series of release candidates, a final 2.0 with new features might be
+available in the middle of 2018.
+
+#### Checklist
+
+- [ ] The `DocumentError` exception is replaced with an error. (#141)
+- [ ] Dependency injection for all kind of handlers. (#279,#314)
+- [ ] A convenient way for document processing chains and branches. (#tba)
+- [ ] Include a guide on upgrading from 1.x.
+- [ ] Remove this document.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ It will contain a finalized version of this document.
 
 ### Branching off 1.x
 
-After that release, a new branch `1.x` is created. This one  will continue to
+After that release, a new branch `1.x` is created. This one will continue to
 support Python 2 and receive bug fixes *at least* until December 31, 2019.
 A *feature freeze* for functionality of the public API is declared.
 
@@ -55,9 +55,9 @@ implications.
 - [ ] All functions and methods are type annotated. MyPy is added to the test
       suite.
 - [ ] A wider choice of type names that are closer oriented on the builtin
-      names are available. (#tba)
+      names are available. (#374)
 - [ ] Objects from the `typing` module can be used as constraints for the
-      `type` rule.
+      `type` rule. (#374)
 - [ ] The `schema` rule only handles mappings, a new `itemrules` replaces the
       part where `schema` tested items in sequences so far. (#tba)
 - [ ] Implementations of rules, coercers etc. can and the contributed should be
@@ -78,7 +78,7 @@ implications.
 ### 2.0 release
 
 After a series of release candidates, a final 2.0 with new features might be
-available in the middle of 2018.
+available by the end of 2018.
 
 #### Checklist
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,6 +83,5 @@ available by the end of 2018.
 #### Checklist
 
 - [ ] The `DocumentError` exception is replaced with an error. (#141)
-- [ ] A convenient way for document processing chains and branches. (#tba)
 - [ ] Include a guide on upgrading from 1.x.
 - [ ] Remove this document.


### PR DESCRIPTION
here's a proposal for a roadmap.

my *impression* is that within about the last year the request for features reduced. beside bug reports the issues rather dealt with details how rules work and usage/usability concerns. this impression leads me to the conclusion that Cerberus in its current state can be used to solve a variety of validation problems.

the decline of Python 2 is happening and dropping it will ease future development. we (will) have a good state of the library that can be used with it anyway. this opens the opportunity for a new breaking release.

the types have grown a little wild, leading to some inconsistencies, e.g. `list` is actually a `Sequence`. it's practically not a show-stopper, but i think we should sort this out. i'll open an issue with details later. as typing gets more important within the Python 3-line, i'd say we should support that too.

[here](https://github.com/funkyfuture/cerberus/blob/roadmap/ROADMAP.md)'s a rendered view of the proposal.