### PR TITLE
Adds some querying options to ErrorTrees

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ RUN pip3.6 install flake8 pytest tox PyYAML Sphinx==1.5.6 \
  && mkdir /home/tox \
  && mv /root/.cache /home/tox/
 
-ARG uid
-RUN useradd --uid=$uid -m tox \
+RUN useradd -m tox \
  && chown -R tox.tox /home/tox/.cache
 
 ADD . .
-RUN chown -R tox.tox .
+RUN mkdir .tox \
+ && chown -R tox.tox .
 
 USER tox

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -187,8 +187,9 @@ class ValidationError(object):
 
 
 class ErrorList(list):
-    """ A list for :class:`~cerberus.errrors.ValidationError` instances that
-        can be queried with the ``in`` keyword for a particular error code. """
+    """ A list for :class:`~cerberus.errors.ValidationError` instances that
+        can be queried with the ``in`` keyword for a particular
+        :class:`~cerberus.errors.ErrorDefinition`. """
     def __contains__(self, error_definition):
         for code in (x.code for x in self):
             if code == error_definition.code:
@@ -210,6 +211,12 @@ class ErrorTreeNode(MutableMapping):
         self.add(error)
         return self
 
+    def __contains__(self, item):
+        if isinstance(item, ErrorDefinition):
+            return item in self.errors
+        else:
+            return item in self.descendants
+
     def __delitem__(self, key):
         del self.descendants[key]
 
@@ -217,10 +224,18 @@ class ErrorTreeNode(MutableMapping):
         return iter(self.errors)
 
     def __getitem__(self, item):
-        return self.descendants.get(item)
+        if isinstance(item, ErrorDefinition):
+            for error in self.errors:
+                if item.code == error.code:
+                    return error
+        else:
+            return self.descendants.get(item)
 
     def __len__(self):
         return len(self.errors)
+
+    def __repr__(self):
+        return self.__str__()
 
     def __setitem__(self, key, value):
         self.descendants[key] = value

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -44,7 +44,10 @@ def assert_fail(document, schema=None, validator=None, update=False,
     actual_errors = validator._errors
 
     assert not (error is not None and errors is not None)
-    assert not (errors is not None and child_errors is not None)
+    assert not (errors is not None and child_errors is not None), (
+        'child_errors can only be tested in '
+        'conjunction with the error parameter'
+    )
     assert not (child_errors is not None and error is None)
     if error is not None:
         assert len(actual_errors) == 1

--- a/cerberus/tests/test_errors.py
+++ b/cerberus/tests/test_errors.py
@@ -57,16 +57,21 @@ def test__error_3():
     assert error.is_logic_error
 
 
-def test_error_tree_1(validator):
+def test_error_tree_from_subschema(validator):
     schema = {'foo': {'schema': {'bar': {'type': 'string'}}}}
     document = {'foo': {'bar': 0}}
     assert_fail(document, schema, validator=validator)
     d_error_tree = validator.document_error_tree
     s_error_tree = validator.schema_error_tree
+
     assert 'foo' in d_error_tree
+
+    assert len(d_error_tree['foo'].errors) == 1, d_error_tree['foo']
+    assert d_error_tree['foo'].errors[0].code == errors.MAPPING_SCHEMA.code
     assert 'bar' in d_error_tree['foo']
     assert d_error_tree['foo']['bar'].errors[0].value == 0
     assert d_error_tree.fetch_errors_from(('foo', 'bar'))[0].value == 0
+
     assert 'foo' in s_error_tree
     assert 'schema' in s_error_tree['foo']
     assert 'bar' in s_error_tree['foo']['schema']
@@ -76,7 +81,7 @@ def test_error_tree_1(validator):
         ('foo', 'schema', 'bar', 'type'))[0].value == 0
 
 
-def test_error_tree_2(validator):
+def test_error_tree_from_anyof(validator):
     schema = {'foo': {'anyof': [{'type': 'string'}, {'type': 'integer'}]}}
     document = {'foo': []}
     assert_fail(document, schema, validator=validator)

--- a/cerberus/tests/test_errors.py
+++ b/cerberus/tests/test_errors.py
@@ -185,6 +185,30 @@ def test_nested_error_paths(validator):
     assert _set['a_list']['schema']['oneof'][1]['regex'].errors[0] == _ref_err
 
 
+def test_queries():
+    schema = {'foo': {'type': 'dict',
+                      'schema':
+                          {'bar': {'type': 'number'}}}}
+    document = {'foo': {'bar': 'zero'}}
+    validator = Validator(schema)
+    validator(document)
+
+    assert 'foo' in validator.document_error_tree
+    assert 'bar' in validator.document_error_tree['foo']
+    assert 'foo' in validator.schema_error_tree
+    assert 'schema' in validator.schema_error_tree['foo']
+
+    assert errors.MAPPING_SCHEMA in validator.document_error_tree['foo'].errors
+    assert errors.MAPPING_SCHEMA in validator.document_error_tree['foo']
+    assert errors.BAD_TYPE in validator.document_error_tree['foo']['bar']
+    assert errors.MAPPING_SCHEMA in validator.schema_error_tree['foo']['schema']
+    assert errors.BAD_TYPE in \
+        validator.schema_error_tree['foo']['schema']['bar']['type']
+
+    assert (validator.document_error_tree['foo'][errors.MAPPING_SCHEMA]
+            .child_errors[0].code == errors.BAD_TYPE.code)
+
+
 def test_basic_error_handler():
     handler = errors.BasicErrorHandler()
     _errors, ref = [], {}

--- a/cerberus/tests/test_schema.py
+++ b/cerberus/tests/test_schema.py
@@ -88,7 +88,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 145
+    max_cache_size = 147
     assert cache_size <= max_cache_size, \
         "There's an unexpected high amount (%s) of cached valid " \
         "definition schemas. Unless you added further tests, " \

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -1245,7 +1245,7 @@ class BareValidator(object):
                                               allow_unknown=allow_unknown)
         try:
             if not validator(value, update=self.update, normalize=False):
-                self._error(validator._errors)
+                self._error(field, errors.MAPPING_SCHEMA, validator._errors)
         except _SchemaRuleTypeError:
             self._error(field, errors.BAD_TYPE_FOR_SCHEMA)
             raise

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -75,8 +75,8 @@ to ``tox``:
 
 You can run the script without any arguments to test the project exactly as
 `Continuous Integration`_ does without having to setup anything.
-If there's a directoy ``.tox`` in the project-folder it will be used to store
-and access cached virtual environments and test-logs.
+The ``tox`` environments are preserved in a volume named ``cerberus-tox``, just
+remove it with ``docker volume rm`` to clean them.
 
 Building the HTML-documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -51,16 +51,23 @@ the following properties:
 You can access the errors per these properties of a :class:`~cerberus.Validator`
 instance after a processing of a document:
 
-  - ``_errors``: This list holds all submitted errors. It is not intended to
-    manipulate errors directly via this attribute. You can test if at least one
-    error with a specific error definition is ``in`` that list.
+  - ``_errors``: This :class:`~cerberus.errors.ErrorsList` instance  holds all
+    submitted errors. It is not intended to manipulate errors directly via this
+    attribute. You can test if at least one error with a specific error
+    definition is ``in`` that list.
 
   - ``document_error_tree``: A ``dict``-like object that allows you to query
-    nodes corresponding to your document. That node's errors are contained in
-    its :attr:`errors` property which you can test like ``_errors`` and are
-    yielded when iterating over a node. If no errors occurred in a node or
+    nodes corresponding to your document.
+    The subscript notation on a node allows to fetch either a specific error
+    that matches the given :class:`~cerberus.errors.ErrorDefinition` or a child
+    node with the given key.
+    If there's no matching error respectively no errors occurred in a node or
     below, :obj:`None` will be returned instead.
-
+    A node can also be tested with the ``in`` operator with either an
+    :class:`~cerberus.errors.ErrorDefinition` or a possible child node's key.
+    A node's errors are contained in its :attr:`errors` property which is also
+    an :class:`~cerberus.errors.ErrorsList`. Its members are yielded when
+    iterating over a node.
   - ``schema_error_tree``: Similarly for the used schema.
 
 .. versionchanged:: 1.0
@@ -79,6 +86,11 @@ Examples
     >>> cerberus.errors.BAD_TYPE in v._errors
     True
     >>> v.document_error_tree['cats'].errors == v.schema_error_tree['cats']['type'].errors
+    True
+    >>> cerberus.errors.BAD_TYPE in v.document_error_tree['cats']
+    True
+    >>> v.document_error_tree['cats'][cerberus.errors.BAD_TYPE] \
+    ...     == v.document_error_tree['cats'].errors[0]
     True
     >>> error = v.document_error_tree['cats'].errors[0]
     >>> error.document_path

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -400,6 +400,11 @@ according to the prefixes logics ``all``, ``any``, ``one`` or ``none``.
 ``oneof``   Validates if *exactly one* of the provided constraints applies.
 ==========  ====================================================================
 
+.. note::
+
+    :doc:`Normalization <normalization-rules>` cannot be used in the rule sets
+    within the constraints of these rules.
+
 For example, to verify that a field's value is a number between 0 and 10 or 100
 and 110, you could do the following:
 

--- a/run-docker-tests
+++ b/run-docker-tests
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+IMAGE_NAME=cerberus-tox
+VOLUME_NAME=cerberus-tox
+
 cd "$(dirname ${0})"
 
-docker build -t cerberus-tox --build-arg uid=$(id -u) . && \
-if [ -d ".tox" ]; then
-    docker run --rm --entrypoint="tox" -v "$(pwd)/.tox:/src/.tox" cerberus-tox "${@}"
-else
-    docker run --rm --entrypoint="tox" cerberus-tox "${@}"
-fi
+docker build -t $IMAGE_NAME --build-arg uid=$(id -u) . || exit 1
+[ -z "$(docker volume ls -q --filter 'name=$VOLUME_NAME')" ] \
+    && docker volume create $VOLUME_NAME
+docker run --rm -v "$VOLUME_NAME:/src/.tox" $IMAGE_NAME "${@}"
+EXIT_CODE=$?
 
 cd -
+exit $EXIT_CODE


### PR DESCRIPTION
the docs and tests should explain what this is about.

the `errors.MAPPING_SCHMEMA` error hasn't been submitted so far as it's implicit that errors in the lower parts of the doc error tree implies such. but it also makes it tricky to for query such errors. hence i added this error to be emitted.