### PR TITLE
Doc misspells

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Contributors
 - Bryan W. Weber
 - C.D. Clark III
 - Christian Hogan
+- Connor Zapfel
 - Damián Nohales
 - Danielle Pizzolli
 - Davis Kirkendall

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -81,7 +81,7 @@ remove it with ``docker volume rm`` to clean them.
 Building the HTML-documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To preview the rendered HTML-documentation you must intially install the
+To preview the rendered HTML-documentation you must initially install the
 documentation framework and a theme:
 
 .. code-block:: console

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -58,7 +58,7 @@ instance after a processing of a document:
 
   - ``document_error_tree``: A ``dict``-like object that allows you to query
     nodes corresponding to your document.
-    The subscript notation on a node allows to fetch either a specific error
+    The subscript notation on a node allows you to fetch either a specific error
     that matches the given :class:`~cerberus.errors.ErrorDefinition` or a child
     node with the given key.
     If there's no matching error respectively no errors occurred in a node or

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -56,9 +56,9 @@ instance after a processing of a document:
     attribute. You can test if at least one error with a specific error
     definition is ``in`` that list.
 
-  - ``document_error_tree``: A ``dict``-like object that allows you to query
+  - ``document_error_tree``: A ``dict``-like object that allows one to query
     nodes corresponding to your document.
-    The subscript notation on a node allows you to fetch either a specific error
+    The subscript notation on a node allows one to fetch either a specific error
     that matches the given :class:`~cerberus.errors.ErrorDefinition` or a child
     node with the given key.
     If there's no matching error respectively no errors occurred in a node or

--- a/docs/schemas.rst
+++ b/docs/schemas.rst
@@ -29,7 +29,7 @@ validation schema. You can furthermore instantiate more
 :attr:`~cerberus.Validator.schema_registry` of a validator. You may also set
 these as keyword-arguments upon intitialization.
 
-Using registries is particulary interesting if
+Using registries is particularly interesting if
 
   - schemas shall include references to themselves, vulgo: schema recursion
   - schemas contain a lot of reused parts and are supposed to be

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -66,7 +66,7 @@ Validates if *any* of the provided constraints validates the field. See `\*of-ru
 
 dependencies
 ------------
-This rule allows to define either a single field name, a sequence of field
+This rule allows one to define either a single field name, a sequence of field
 names or a :term:`mapping` of field names and a sequence of allowed values as
 required in the document if the field defined upon is present in the document.
 
@@ -167,7 +167,7 @@ supported:
 
 When a subdocument is processed the lookup for a field in question starts at
 the level of that document. In order to address the processed document as
-root level, the declaration has to start with a ``^``. An occurance of two
+root level, the declaration has to start with a ``^``. An occurrence of two
 initial carets (``^^``) is interpreted as a literal, single ``^`` with no
 special meaning.
 
@@ -708,7 +708,7 @@ A list of types can be used to allow different values:
     exist for the same field (only `nullable`_ and `readonly`_ are considered
     beforehand). In the occurrence of a type failure subsequent validation
     rules on the field will be skipped and validation will continue on other
-    fields. This allows to safely assume that field type is correct when other
+    fields. This allows one to safely assume that field type is correct when other
     (standard or custom) rules are invoked.
 
 .. versionchanged:: 1.0


### PR DESCRIPTION
Just fixed some typos in the docs from Issue #390. The issue is a little old so not all of them still existed.