### PR TITLE
Omits warning when no schema for the meta rule constraint is avail

### DIFF
--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -1561,7 +1561,7 @@ class InspectedValidator(type):
             except Exception:
                 result = {}
 
-        if not result:
+        if not result and method_name != '_validate_meta':
             warn(
                 "No validation schema is defined for the arguments of rule "
                 "'%s'" % method_name.split('_', 2)[-1]


### PR DESCRIPTION
As per default there is none defined and that gets noisy.