### PR TITLE
Adjustments for pre-commit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,11 @@
-.*
+.benchmarks
+.cache
+.dockerignore
+.eggs
+.pytest_cache
+.readthedocs.yml
+.tox
+.travis.yml
 **/*.egg-info
 **/*.orig
 **/*.pyc

--- a/.linting-config.yaml
+++ b/.linting-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: stable
     hooks:
       - id: black
-        args: [--check, --safe, --skip-string-normalization, cerberus, setup.py]
+        args: [--check, --safe, --skip-string-normalization]
         python_version: python3.6
         types:
           - python

--- a/.linting-config.yaml
+++ b/.linting-config.yaml
@@ -17,3 +17,7 @@ repos:
       - id: debug-statements
         types:
           - python
+      - id: flake8
+        types:
+          - python
+        exclude: ^docs/conf.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: stable
     hooks:
       - id: black
-        args: [--quiet, --safe, --skip-string-normalization, cerberus, setup.py]
+        args: [--quiet, --safe, --skip-string-normalization]
         python_version: python3.6
         types:
           - python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,7 @@ repos:
       - id: debug-statements
         types:
           - python
+      - id: flake8
+        types:
+          - python
+        exclude: ^docs/conf.py$

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM funkyfuture/nest-of-serpents
 ENTRYPOINT tox
 WORKDIR /src
 
-RUN pip3.6 install flake8 pytest tox PyYAML Sphinx==1.5.6 \
+RUN pip3.6 install black flake8 pre-commit pytest tox PyYAML Sphinx \
  && mkdir /home/tox \
  && mv /root/.cache /home/tox/
 

--- a/cerberus/tests/test_normalization.py
+++ b/cerberus/tests/test_normalization.py
@@ -133,8 +133,8 @@ def test_custom_coerce_and_rename():
 
 
 def test_coerce_chain():
-    drop_prefix = lambda x: x[2:]
-    upper = lambda x: x.upper()
+    drop_prefix = lambda x: x[2:]  # noqa: E731
+    upper = lambda x: x.upper()  # noqa: E731
     schema = {'foo': {'coerce': [hex, drop_prefix, upper]}}
     assert_normalized({'foo': 15}, {'foo': 'F'}, schema)
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,10 @@ basepython=python3.6
 deps=pre-commit
 commands=pre-commit run --config .linting-config.yaml --all-files
 
+[flake8]
+max-line-length=88
+ignore=E203,W503
+
 [tox:travis]
 2.7 = py27
 3.4 = py34


### PR DESCRIPTION
i was wrong about black's capabilities or rather i missed the point that flake8 does additionaly detect unused imports. also i missed the point that pre-commit calls the plugins per changed file.

i'm not sure if i got it correctly. when black reformats code, this change doesn't get added to the commit and i have to commit a second time. is this supposedly so?