### PR TITLE
Fix test default none nonnullable

### DIFF
--- a/cerberus/tests/test_normalization.py
+++ b/cerberus/tests/test_normalization.py
@@ -3,6 +3,8 @@
 from copy import deepcopy
 from tempfile import NamedTemporaryFile
 
+from pytest import mark
+
 from cerberus import Validator, errors
 from cerberus.tests import (
     assert_fail,
@@ -10,6 +12,10 @@ from cerberus.tests import (
     assert_normalized,
     assert_success,
 )
+
+
+def must_not_be_called(*args, **kwargs):
+    raise RuntimeError('This shall not be called.')
 
 
 def test_coerce():
@@ -264,15 +270,10 @@ def test_coercion_of_sequence_items(validator):
         assert isinstance(x, float)
 
 
-def test_default_missing():
-    _test_default_missing({'default': 'bar_value'})
-
-
-def test_default_setter_missing():
-    _test_default_missing({'default_setter': lambda doc: 'bar_value'})
-
-
-def _test_default_missing(default):
+@mark.parametrize(
+    'default', ({'default': 'bar_value'}, {'default_setter': lambda doc: 'bar_value'})
+)
+def test_default_missing(default):
     bar_schema = {'type': 'string'}
     bar_schema.update(default)
     schema = {'foo': {'type': 'string'}, 'bar': bar_schema}
@@ -281,18 +282,10 @@ def _test_default_missing(default):
     assert_normalized(document, expected, schema)
 
 
-def test_default_existent():
-    _test_default_existent({'default': 'bar_value'})
-
-
-def test_default_setter_existent():
-    def raise_error(doc):
-        raise RuntimeError('should not be called')
-
-    _test_default_existent({'default_setter': raise_error})
-
-
-def _test_default_existent(default):
+@mark.parametrize(
+    'default', ({'default': 'bar_value'}, {'default_setter': must_not_be_called})
+)
+def test_default_existent(default):
     bar_schema = {'type': 'string'}
     bar_schema.update(default)
     schema = {'foo': {'type': 'string'}, 'bar': bar_schema}
@@ -300,18 +293,10 @@ def _test_default_existent(default):
     assert_normalized(document, document.copy(), schema)
 
 
-def test_default_none_nullable():
-    _test_default_none_nullable({'default': 'bar_value'})
-
-
-def test_default_setter_none_nullable():
-    def raise_error(doc):
-        raise RuntimeError('should not be called')
-
-    _test_default_none_nullable({'default_setter': raise_error})
-
-
-def _test_default_none_nullable(default):
+@mark.parametrize(
+    'default', ({'default': 'bar_value'}, {'default_setter': must_not_be_called})
+)
+def test_default_none_nullable(default):
     bar_schema = {'type': 'string', 'nullable': True}
     bar_schema.update(default)
     schema = {'foo': {'type': 'string'}, 'bar': bar_schema}
@@ -319,15 +304,10 @@ def _test_default_none_nullable(default):
     assert_normalized(document, document.copy(), schema)
 
 
-def test_default_none_nonnullable():
-    _test_default_none_nonnullable({'default': 'bar_value'})
-
-
-def test_default_setter_none_nonnullable():
-    _test_default_none_nonnullable({'default_setter': lambda doc: 'bar_value'})
-
-
-def _test_default_none_nonnullable(default):
+@mark.parametrize(
+    'default', ({'default': 'bar_value'}, {'default_setter': lambda doc: 'bar_value'})
+)
+def test_default_none_nonnullable(default):
     bar_schema = {'type': 'string', 'nullable': False}
     bar_schema.update(default)
     schema = {'foo': {'type': 'string'}, 'bar': bar_schema}
@@ -346,15 +326,10 @@ def test_default_none_default_value():
     assert_normalized(document, expected, schema)
 
 
-def test_default_missing_in_subschema():
-    _test_default_missing_in_subschema({'default': 'bar_value'})
-
-
-def test_default_setter_missing_in_subschema():
-    _test_default_missing_in_subschema({'default_setter': lambda doc: 'bar_value'})
-
-
-def _test_default_missing_in_subschema(default):
+@mark.parametrize(
+    'default', ({'default': 'bar_value'}, {'default_setter': lambda doc: 'bar_value'})
+)
+def test_default_missing_in_subschema(default):
     bar_schema = {'type': 'string'}
     bar_schema.update(default)
     schema = {

--- a/cerberus/tests/test_normalization.py
+++ b/cerberus/tests/test_normalization.py
@@ -320,19 +320,20 @@ def _test_default_none_nullable(default):
 
 
 def test_default_none_nonnullable():
-    _test_default_none_nullable({'default': 'bar_value'})
+    _test_default_none_nonnullable({'default': 'bar_value'})
 
 
 def test_default_setter_none_nonnullable():
-    _test_default_none_nullable({'default_setter': lambda doc: 'bar_value'})
+    _test_default_none_nonnullable({'default_setter': lambda doc: 'bar_value'})
 
 
 def _test_default_none_nonnullable(default):
     bar_schema = {'type': 'string', 'nullable': False}
     bar_schema.update(default)
     schema = {'foo': {'type': 'string'}, 'bar': bar_schema}
-    document = {'foo': 'foo_value', 'bar': 'bar_value'}
-    assert_normalized(document, document.copy(), schema)
+    document = {'foo': 'foo_value', 'bar': None}
+    expected = {'foo': 'foo_value', 'bar': 'bar_value'}
+    assert_normalized(document, expected, schema)
 
 
 def test_default_none_default_value():


### PR DESCRIPTION
see #427

```
Fix `test_{default,default_setter}_none_nonnullable`

Both tests called the wrong helper function.

Furthermore `_test_default_none_nonnullable` mimicked the behaviour of
`_test_default_existent`, now it actually tests what its name suggests.
```

cc @funkyfuture 