### PR TITLE
Allow document being validated to be updated (close #440)

### DIFF
--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -6,7 +6,7 @@ from datetime import datetime, date
 from random import choice
 from string import ascii_lowercase
 
-from pytest import mark
+from pytest import mark, fail
 
 from cerberus import errors, Validator
 from cerberus.tests import (
@@ -1838,3 +1838,22 @@ def test_contains(constraint):
         errors.MISSING_MEMBERS
     ].info[0]
     assert any(x in missing_actors for x in ('Eric Idle', 'Terry Gilliam'))
+
+
+def test_can_update_document_under_validation():
+    class MyValidator(Validator):
+        def _validate_is_witch(self, is_witch, field, value):
+            """ {'type': 'boolean'} """
+            # If you have to ask, she's a witch
+            if is_witch:
+                self._error(field, 'Burn her!')
+                self.document['duck_weight'] = True
+
+    schema = {'candidate': {'is_witch': True}}
+    validator = MyValidator(schema)
+
+    try:
+        validator.validate({'candidate': 'Connie Booth'}, schema)
+    except RuntimeError:
+        fail('Cannot modify document under validation')
+

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -1853,6 +1853,6 @@ def test_can_update_document_under_validation():
     validator = MyValidator(schema)
 
     try:
-        validator.validate({'candidate': 'Connie Booth'}, schema)
+        validator.validate({'candidate': 'Connie Booth'})
     except RuntimeError:
         fail('Cannot modify document under validation')

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -1856,4 +1856,3 @@ def test_can_update_document_under_validation():
         validator.validate({'candidate': 'Connie Booth'}, schema)
     except RuntimeError:
         fail('Cannot modify document under validation')
-

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -1853,6 +1853,6 @@ def test_can_update_document_under_validation():
     validator = MyValidator(schema)
 
     try:
-        validator.validate({'candidate': 'Connie Booth'})
+        validator.validate({'candidate': 'Connie Booth'}, schema)
     except RuntimeError:
         fail('Cannot modify document under validation')

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -952,7 +952,7 @@ class BareValidator(object):
         if normalize:
             self.__normalize_mapping(self.document, self.schema)
 
-        for field in self.document:
+        for field in list(self.document):
             if self.ignore_none_values and self.document[field] is None:
                 continue
             definitions = self.schema.get(field)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ DESCRIPTION = (
     "Python dictionaries."
 )
 LONG_DESCRIPTION = open('README.rst').read()
-VERSION = '1.2'
+VERSION = 'v1.2-cri.1.0'
 
 setup_requires = (
     ['pytest-runner'] if any(x in sys.argv for x in ('pytest', 'test', 'ptr')) else []


### PR DESCRIPTION
Fixes #440 - Restores the ability to modify the document under validation, which used to work in v0.9.2