### PR TITLE
Honor `ignore_none_values` for excludes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Core maintainers
 Contributors
 ~~~~~~~~~~~~
 
+- Alexander Dietmüller
 - Antoine Lubineau
 - Arsh Singh
 - Audric Schiltknecht

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ New
   the next major release of Cerbers (`#385`_)
 - The ``meta`` pseudo-rule can be used to store arbitrary application data
   related to a field in a schema
+- The `excludes` validator takes `ignore_none_values` into account
 - **Python 2.6 and 3.3 are no longer supported**
 
 Fixed

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -1699,6 +1699,21 @@ def test_multiples_exclusions():
     assert_success({'that_field': {}, 'bazo_field': {}}, schema)
 
 
+def test_exlude_none():
+    """If `ignore_none_values` is True, None is not considered for exclusion."""
+    schema = {
+        'this_field': {'type': 'dict', 'excludes': 'that_field'},
+        'that_field': {'type': 'dict'},
+    }
+    document = {'this_field': {}, 'that_field': None}
+
+    validator = Validator(schema, ignore_none_values=True)
+    assert_success(document, validator=validator)
+
+    validator = Validator(schema, ignore_none_values=False)
+    assert_fail(document, validator=validator)
+
+
 def test_bad_excludes_fields(validator):
     validator.schema = {
         'this_field': {

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -1171,7 +1171,14 @@ class BareValidator(object):
 
                 self._unrequired_by_excludes.add(excluded_field)
 
-        if any(excluded_field in self.document for excluded_field in excluded_fields):
+        def _ignore_field(field):
+            # If the field is None and ignore_none_values is set, ignore it.
+            return self.document[field] is None and self.ignore_none_values
+
+        if any(
+            excluded_field in self.document and not _ignore_field(excluded_field)
+            for excluded_field in excluded_fields
+        ):
             exclusion_str = ', '.join(
                 "'{0}'".format(field) for field in excluded_fields
             )


### PR DESCRIPTION
The `ignore_none_values` allows to treat None like a missing field, i.e.
ignore fields set to None.
This should also extend to the `exludes` validator: Fields set to None should
be ignored and not raise an error, if `ignore_none_values` is True.

Contributions:

- Include check for `if_none_values` in `_validate_excludes`

- Test the feature

- Updates to AUTHORS and CHANGES