### PR TITLE
Backports some insights from type annotating the whole code base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,10 @@ develop-eggs
 # Installer logs
 pip-log.txt
 
-# Unit test / coverage reports
+# Testing
 .cache
 .coverage
+.mypy_cache/
 .pytest_cache/
 .tox
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,8 @@ Fixed
 Improved
 ~~~~~~~~
 - Suppress DeprecationWarning about collections.abc (`#451`_)
-- Omit warning when no schema for ``meta`` rule constraint is available (`#425`_)
+- Omit warning when no schema for ``meta`` rule constraint is available
+  (`#425`_)
 - Add ``.eggs`` to .gitignore file (`#420`_)
 - Reformat code to match Black code-style (`#402`_)
 - Perform lint checks and fixes on staged files, as a pre-commit hook (`#402`_)
@@ -44,10 +45,13 @@ Improved
 - Remove ``Registry`` from top level namespace (`#354`_)
 - Remove ``utils.is_class``
 - Check the ``empty`` rule against values of type ``Sized``
+- Various micro optimizations and 'safety belts' that were inspired by adding
+  type annotations to a branch of the code base
 
 Docs
 ~~~~
-- Fix semantical versioning naming. There are only two hard things in Computer Science: cache invalidation and naming things -- *Phil Karlton* (`#429`_)
+- Fix semantical versioning naming. There are only two hard things in Computer
+  Science: cache invalidation and naming things -- *Phil Karlton* (`#429`_)
 - Improve documentation of the regex rule (`#389`_)
 - Expand upon `validator` rules (`#320`_)
 - Include all errors definitions in API docs (`#404`_)

--- a/cerberus/tests/test_utils.py
+++ b/cerberus/tests/test_utils.py
@@ -1,0 +1,11 @@
+from cerberus.utils import compare_paths_lt
+
+
+def test_compare_paths():
+    lesser = ('a_dict', 'keysrules')
+    greater = ('a_dict', 'valuesrules')
+    assert compare_paths_lt(lesser, greater)
+
+    lesser += ('type',)
+    greater += ('regex',)
+    assert compare_paths_lt(lesser, greater)

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -270,8 +270,8 @@ class BareValidator(object):
             self._errors.extend(args[0])
             self._errors.sort()
             for error in args[0]:
-                self.document_error_tree += error
-                self.schema_error_tree += error
+                self.document_error_tree.add(error)
+                self.schema_error_tree.add(error)
                 self.error_handler.emit(error)
         elif len(args) == 2 and isinstance(args[1], _str_type):
             self._error(args[0], errors.CUSTOM, args[1])
@@ -411,7 +411,7 @@ class BareValidator(object):
         for part in parts:
             if part not in context:
                 return None, None
-            context = context.get(part)
+            context = context.get(part, {})
 
         return parts[-1], context
 
@@ -775,7 +775,8 @@ class BareValidator(object):
                 warn(
                     "Normalizing keys of {path}: {key} already exists, "
                     "its value is replaced.".format(
-                        path='.'.join(self.document_path + (field,)), key=k
+                        path='.'.join(str(x) for x in self.document_path + (field,)),
+                        key=k,
                     )
                 )
                 mapping[field][result[k]] = mapping[field][k]
@@ -1135,7 +1136,9 @@ class BareValidator(object):
     def _validate_dependencies(self, dependencies, field, value):
         """ {'type': ('dict', 'hashable', 'list'),
              'check_with': 'dependencies'} """
-        if isinstance(dependencies, _str_type):
+        if isinstance(dependencies, _str_type) or not isinstance(
+            dependencies, (Iterable, Mapping)
+        ):
             dependencies = (dependencies,)
 
         if isinstance(dependencies, Sequence):


### PR DESCRIPTION
so far, type annotations turned out to be a challenging type of meditation, it's a bumpy field. anyway, here are some minor changes from its result that don't break or extend anything, yet everyone should feel safer and faster served when using Cerberus.

The changes fall into these categories:
- expatiating return values in branches
- covering missing handling of input types in callables
- optimizing by reducing lookups
- optimizing by using more effective container types
- removing redundant interfaces
- removing unneeded defaults in signatures
- completing interfaces of abstract type implementations