### PR TITLE
Restricts the scope of planned type annotations to the public API

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,8 +47,8 @@ implications.
   - [ ] A Python 3-style metaclass.
   - [ ] Using `super()` to call overridden methods.
   - [ ] Usage of dictionary comprehensions.
-- [ ] All functions and methods are type annotated. MyPy is added to the test
-      suite.
+- [ ] All *public* functions and methods are type annotated. MyPy is added to 
+      the test suite to validate these.
 - [ ] A wider choice of type names that are closer oriented on the builtin
       names are available. (#374)
 - [ ] Objects from the `typing` module can be used as constraints for the


### PR DESCRIPTION
this is a question, or rather the answer to it, that i wanted to raise for a while.

so, the question was whether to stick with the goal of type annotating the whole codebase. i did that, and as a result i came to the conclusion that it doesn't make sense, because of Cerberus' design and paradigms of Python typing that don't match well.

as some time went by, i got the impression that it is a common sense now that a public API is a good idea. in my experience it really is helpful during the development of applications. there's immediate feedback by modern IDEs and `mypy` hints on changed APIs without writing tests. and to the extent of the public parts, it is doable with to add workable annotations.

the question that remains is whether annotations in the non-public parts that do not hurt shall be allowed or not.