### PR TITLE
Don't ignore all exceptions during coercions for nullable fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Contributors
 - Martin Ortbauer
 - Matthew Ellison
 - Michael Klich
+- Nik Haldimann
 - Nikita Melentev
 - Nikita Vlaznev
 - Paul Weaver

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ Improved
 ~~~~~~~~
 - Add ``maintainer`` and ``maintainer_email`` to setup.py (`#481`_)
 - Add ``project_urls`` to setup.py (`#480`_)
+- Don't ignore all exceptions during coercions for nullable fields. If a
+coercion raises an exception for a nullable field where the field is not
+``None`` the validation now fails.
 
 .. _`#484`: https://github.com/pyeve/cerberus/issues/484
 .. _`#482`: https://github.com/pyeve/cerberus/issues/482

--- a/cerberus/tests/test_normalization.py
+++ b/cerberus/tests/test_normalization.py
@@ -170,6 +170,18 @@ def test_nullables_dont_fail_coerce():
     assert_normalized(document, document, schema)
 
 
+def test_nullables_fail_coerce_on_non_null_values(validator):
+    def failing_coercion(value):
+        raise Exception("expected to fail")
+
+    schema = {'foo': {'coerce': failing_coercion, 'nullable': True, 'type': 'integer'}}
+    document = {'foo': None}
+    assert_normalized(document, document, schema)
+
+    validator({'foo': 2}, schema)
+    assert errors.COERCION_FAILED in validator._errors
+
+
 def test_normalized():
     schema = {'amount': {'coerce': int}}
     document = {'amount': '2'}

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -723,7 +723,7 @@ class BareValidator(object):
         try:
             return processor(value)
         except Exception as e:
-            if not nullable and e is not TypeError:
+            if not (nullable and value is None):
                 self._error(field, error, str(e))
             return value
 


### PR DESCRIPTION
Only ignore exceptions if a value for a nullable field is not null.
Previously all exceptions during custom coerction were ignored with nullable
fields. The developer and/or user most likely wants to know about
exceptions that happen during coercion - this leads to hard to debug
problems otherwise.

The purpose of the `e is not TypeError` condition was unclear. As far as I
know this condition can never be false (`e` is an instance of an exception,
not an exception class).

I think this is still in line with the original intent of this code, which
was to make common coercions like `float` work with nullable fields out
of the box: https://github.com/pyeve/cerberus/issues/269