### PR TITLE
Types enhancements for Cerberus 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       python: "3.6"
     - env: TOXENV=py37
       python: "3.7"
+#    - env: TOXENV=py38
+#      python: "3.8"
     - env: TOXENV=pypy3
       python: "pypy3.5-6.0"
     - env: TOXENV=doclinks

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New
 ~~~
 
 - Classes can be used as constraint for the ``type`` rule (`#374`_)
+- The abstract base classes of the standard library's ``collections.abc``
+  module are available as named types for the ``type`` rule (`#374`_)
 
 Changed
 ~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Cerberus is a collaboratively funded project, see the `funding page`_.
 In Development
 --------------
 
+New
+~~~
+
+- Classes can be used as constraint for the ``type`` rule (`#374`_)
+
 Fixed
 ~~~~~~
 
@@ -14,6 +19,7 @@ Fixed
 
 .. _`#494`: https://github.com/pyeve/cerberus/issues/494
 .. _`#493`: https://github.com/pyeve/cerberus/issues/493
+.. _`#374`: https://github.com/pyeve/cerberus/issues/374
 
 Version 1.3.1
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,13 @@ New
 
 - Classes can be used as constraint for the ``type`` rule (`#374`_)
 
+Changed
+~~~~~~~
+
+- Most of Python's builtin data types are available as named constraint for the
+  ``type`` rule. They do not match their builtin subtypes, e.g. ``True`` isn't
+  recognized as ``"integer"``, this also applies to ``date``. (`#374`_)
+
 Fixed
 ~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ New
 - Classes can be used as constraint for the ``type`` rule (`#374`_)
 - The abstract base classes of the standard library's ``collections.abc``
   module are available as named types for the ``type`` rule (`#374`_)
+- Generic type aliases from the :mod:`typing` module can be used as constraints
+  for the ``type`` rule, including parametrized ones a.k.a. compound types
+  (`#374`_)
 
 Changed
 ~~~~~~~

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,7 +53,7 @@ implications.
   - [x] Usage of dictionary comprehensions.
 - [x] All *public* functions and methods are type annotated. MyPy is added to
       the test suite to validate these.
-- [ ] A wider choice of type names that are closer oriented on the builtin
+- [x] A wider choice of type names that are closer oriented on the builtin
       names are available. (#374)
 - [ ] Objects from the `typing` module can be used as constraints for the
       `type` rule. (#374)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,7 +55,7 @@ implications.
       the test suite to validate these.
 - [x] A wider choice of type names that are closer oriented on the builtin
       names are available. (#374)
-- [ ] Objects from the `typing` module can be used as constraints for the
+- [x] Objects from the `typing` module can be used as constraints for the
       `type` rule. (#374)
 - [ ] Implementations of rules, coercers etc. can and the contributed should be
       qualified as such by metadata-annotating decorators. (With the intend to

--- a/cerberus/base.py
+++ b/cerberus/base.py
@@ -389,17 +389,22 @@ class UnconcernedValidator(metaclass=ValidatorMeta):
     )  # type: ClassVar[Tuple[str, ...]]
     """ Rules that will be processed in that order before any other. """
     types_mapping = {
-        'binary': TypeDefinition('binary', (bytes, bytearray), ()),
         'boolean': TypeDefinition('boolean', (bool,), ()),
+        'bytearray': TypeDefinition('bytearray', (bytearray,), ()),
+        'bytes': TypeDefinition('bytes', (bytes,), ()),
+        'complex': TypeDefinition('complex', (complex,), ()),
         'container': TypeDefinition('container', (Container,), (str,)),
-        'date': TypeDefinition('date', (date,), ()),
+        'date': TypeDefinition('date', (date,), (datetime,)),
         'datetime': TypeDefinition('datetime', (datetime,), ()),
         'dict': TypeDefinition('dict', (Mapping,), ()),
-        'float': TypeDefinition('float', (float, int), ()),
-        'integer': TypeDefinition('integer', (int,), ()),
-        'list': TypeDefinition('list', (Sequence,), (str,)),
+        'float': TypeDefinition('float', (float,), ()),
+        'frozenset': TypeDefinition('frozenset', (frozenset,), ()),
+        'integer': TypeDefinition('integer', (int,), (bool,)),
+        'iterable': TypeDefinition('iterable', (Iterable,), ()),
+        'list': TypeDefinition('list', (list,), ()),
         'number': TypeDefinition('number', (int, float), (bool,)),
         'set': TypeDefinition('set', (set,), ()),
+        'sequence': TypeDefinition('sequence', (Sequence,), ()),
         'string': TypeDefinition('string', (str,), ()),
         'tuple': TypeDefinition('tuple', (tuple,), ()),
         'type': TypeDefinition('type', (type,), ()),
@@ -957,7 +962,7 @@ class UnconcernedValidator(metaclass=ValidatorMeta):
     def _normalize_coerce(self, mapping, schema):
         """ {'oneof': [
                 {'type': 'callable'},
-                {'type': 'list',
+                {'type': 'iterable',
                  'itemsrules': {'oneof': [{'type': 'callable'},
                                           {'type': 'string'}]}},
                 {'type': 'string'}
@@ -1476,7 +1481,7 @@ class UnconcernedValidator(metaclass=ValidatorMeta):
             self._error(field, errors.EXCLUDES_FIELD, exclusion_str)
 
     def _validate_forbidden(self, forbidden_values, field, value):
-        """ {'type': 'list'} """
+        """ {'type': 'iterable'} """
         if isinstance(value, str):
             if value in forbidden_values:
                 self._error(field, errors.FORBIDDEN_VALUE, value)

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -434,7 +434,7 @@ class BasicErrorHandler(BaseErrorHandler):
         0x21: "'{0}' is not a document, must be a dict",
         0x22: "empty values not allowed",
         0x23: "null value not allowed",
-        0x24: "must be of {constraint} type",
+        0x24: "must be one of these types: {constraint}",
         0x26: "length of list should be {constraint}, it is {0}",
         0x27: "min length is {constraint}",
         0x28: "max length is {constraint}",

--- a/cerberus/platform.py
+++ b/cerberus/platform.py
@@ -1,3 +1,16 @@
 """ Platform-dependent objects """
 
-pass
+import sys
+
+
+if sys.version_info < (3, 7):
+    from typing import _ForwardRef as ForwardRef  # noqa: F401
+    from typing import GenericMeta as _GenericAlias  # noqa: F401
+
+    TYPE_ALIAS_ORIGIN_ATTRIBUTE = "__extra__"
+
+else:
+    from typing import ForwardRef  # type: ignore  # noqa: F401
+    from typing import _GenericAlias  # type: ignore  # noqa: F401
+
+    TYPE_ALIAS_ORIGIN_ATTRIBUTE = "__origin__"

--- a/cerberus/platform.py
+++ b/cerberus/platform.py
@@ -4,13 +4,46 @@ import sys
 
 
 if sys.version_info < (3, 7):
-    from typing import _ForwardRef as ForwardRef  # noqa: F401
-    from typing import GenericMeta as _GenericAlias  # noqa: F401
+    from typing import _ForwardRef as ForwardRef
+    from typing import GenericMeta as _GenericAlias
+    from typing import _Union, Union
 
-    TYPE_ALIAS_ORIGIN_ATTRIBUTE = "__extra__"
+    def get_type_args(tp):
+        if isinstance(tp, (_GenericAlias, _Union)):
+            return tp.__args__
+        return ()
+
+    def get_type_origin(tp):
+        if isinstance(tp, _GenericAlias):
+            return tp.__extra__
+        if isinstance(tp, _Union):
+            return Union
+        return None
+
+
+elif sys.version_info < (3, 8):
+    from typing import ForwardRef, _GenericAlias  # type: ignore
+
+    def get_type_args(tp):
+        if isinstance(tp, _GenericAlias):
+            return tp.__args__
+        return ()
+
+    def get_type_origin(tp):
+        if isinstance(tp, _GenericAlias):
+            return tp.__origin__
+        return None
+
 
 else:
-    from typing import ForwardRef  # type: ignore  # noqa: F401
-    from typing import _GenericAlias  # type: ignore  # noqa: F401
+    from typing import ForwardRef, _GenericAlias
+    from typing import get_args as get_type_args
+    from typing import get_origin as get_type_origin
 
-    TYPE_ALIAS_ORIGIN_ATTRIBUTE = "__origin__"
+
+__all__ = (
+    "ForwardRef",
+    "_GenericAlias",
+    get_type_args.__name__,
+    get_type_origin.__name__,
+)

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from copy import copy
 from typing import Dict, Hashable, MutableMapping, Sequence, Set
 
@@ -132,15 +132,22 @@ class SchemaValidator(UnconcernedValidator):
         else:
             self.target_validator._valid_schemas.add(_hash)
 
-    def _check_with_type(self, field, value):
-        value = (value,) if isinstance(value, str) else value
-        invalid_constraints = ()
+    def _check_with_type_names(self, field, value):
+        if not isinstance(value, Iterable) or isinstance(value, str):
+            value = (value,)
+
+        invalid_constraints = set()
         for constraint in value:
-            if constraint not in self.target_validator.types:
-                invalid_constraints += (constraint,)
+            if (
+                isinstance(constraint, str)
+                and constraint not in self.target_validator.types
+            ):
+                invalid_constraints.add(constraint)
+
         if invalid_constraints:
             self._error(
-                field, 'Unsupported types: {}'.format(", ".join(invalid_constraints))
+                field,
+                'Unsupported type names: {}'.format(", ".join(invalid_constraints)),
             )
 
     def _expand_rules_set_refs(self, schema):

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -13,6 +13,7 @@ from cerberus.base import (
     UnconcernedValidator,
     normalize_rulesset,
 )
+from cerberus.platform import _GenericAlias
 from cerberus.typing import SchemaDict
 
 
@@ -25,7 +26,10 @@ class SchemaValidator(UnconcernedValidator):
         {
             "container_but_not_string": TypeDefinition(
                 "container_but_not_string", (Container,), (str,)
-            )
+            ),
+            "generic_type_alias": TypeDefinition(
+                "generic_type_alias", (_GenericAlias,), ()
+            ),
         }
     )
 

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Mapping
+from collections.abc import Container, Mapping
 from copy import copy
 from typing import Dict, Hashable, MutableMapping, Sequence, Set
 
@@ -23,8 +23,9 @@ class SchemaValidator(UnconcernedValidator):
     types_mapping = UnconcernedValidator.types_mapping.copy()
     types_mapping.update(
         {
-            'callable': TypeDefinition('callable', (Callable,), ()),  # type: ignore
-            'hashable': TypeDefinition('hashable', (Hashable,), ()),
+            "container_but_not_string": TypeDefinition(
+                "container_but_not_string", (Container,), (str,)
+            )
         }
     )
 

--- a/cerberus/tests/conftest.py
+++ b/cerberus/tests/conftest.py
@@ -22,7 +22,7 @@ def validator():
 
 sample_schema = {
     'a_string': {'type': 'string', 'minlength': 2, 'maxlength': 10},
-    'a_binary': {'type': 'binary', 'minlength': 2, 'maxlength': 10},
+    'a_bytestring': {'type': 'bytes', 'minlength': 2, 'maxlength': 10},
     'a_nullable_integer': {'type': 'integer', 'nullable': True},
     'an_integer': {'type': 'integer', 'min': 1, 'max': 100},
     'a_boolean': {'type': 'boolean', 'meta': 'can haz two distinct states'},

--- a/cerberus/tests/test_customization.py
+++ b/cerberus/tests/test_customization.py
@@ -92,7 +92,7 @@ def test_custom_datatype_rule():
     assert_fail(
         {'test_field': 0.0},
         validator=validator,
-        error=('test_field', ('test_field', 'type'), cerberus.errors.TYPE, 'number'),
+        error=('test_field', ('test_field', 'type'), cerberus.errors.TYPE, ('number',)),
     )
     assert_fail(
         {'test_field': 0},

--- a/cerberus/tests/test_errors.py
+++ b/cerberus/tests/test_errors.py
@@ -14,7 +14,7 @@ def test__error_1():
     assert error.schema_path == ('foo', 'type')
     assert error.code == 0x24
     assert error.rule == 'type'
-    assert error.constraint == 'string'
+    assert error.constraint == ('string',)
     assert error.value == 42
     assert error.info == ('string',)
     assert not error.is_group_error
@@ -30,7 +30,7 @@ def test__error_2():
     assert error.schema_path == ('foo', 'keysrules')
     assert error.code == 0x83
     assert error.rule == 'keysrules'
-    assert error.constraint == {'type': 'integer'}
+    assert error.constraint == {'type': ('integer',)}
     assert error.value == {'0': 'bar'}
     assert error.info == ((),)
     assert error.is_group_error
@@ -304,8 +304,8 @@ def test_basic_error_of_errors(validator):
     document = {'foo': 23.42}
     error = ('foo', ('foo', 'oneof'), errors.ONEOF, schema['foo']['oneof'], ())
     child_errors = [
-        (error[0], error[1] + (0, 'type'), errors.TYPE, 'integer'),
-        (error[0], error[1] + (1, 'type'), errors.TYPE, 'string'),
+        (error[0], error[1] + (0, 'type'), errors.TYPE, ('integer',)),
+        (error[0], error[1] + (1, 'type'), errors.TYPE, ('string',)),
     ]
     assert_fail(
         document, schema, validator=validator, error=error, child_errors=child_errors
@@ -314,8 +314,8 @@ def test_basic_error_of_errors(validator):
         'foo': [
             errors.BasicErrorHandler.messages[0x92],
             {
-                'oneof definition 0': ['must be of integer type'],
-                'oneof definition 1': ['must be of string type'],
+                'oneof definition 0': ["must be one of these types: ('integer',)"],
+                'oneof definition 1': ["must be one of these types: ('string',)"],
             },
         ]
     }

--- a/cerberus/tests/test_errors.py
+++ b/cerberus/tests/test_errors.py
@@ -38,10 +38,10 @@ def test__error_2():
 
 
 def test__error_3():
-    valids = [
+    valids = (
         {'type': 'string', 'regex': '0x[0-9a-f]{2}'},
         {'type': 'integer', 'min': 0, 'max': 255},
-    ]
+    )
     v = Validator(schema={'foo': {'oneof': valids}})
     v.document = {'foo': '0x100'}
     v._error('foo', errors.ONEOF, (), 0, 2)
@@ -300,7 +300,7 @@ def test_basic_error_handler():
 
 
 def test_basic_error_of_errors(validator):
-    schema = {'foo': {'oneof': [{'type': 'integer'}, {'type': 'string'}]}}
+    schema = {'foo': {'oneof': ({'type': 'integer'}, {'type': 'string'})}}
     document = {'foo': 23.42}
     error = ('foo', ('foo', 'oneof'), errors.ONEOF, schema['foo']['oneof'], ())
     child_errors = [

--- a/cerberus/tests/test_normalization.py
+++ b/cerberus/tests/test_normalization.py
@@ -40,7 +40,7 @@ def test_normalize_tuples():
     # https://github.com/pyeve/cerberus/issues/271
     schema = {
         'my_field': {
-            'type': 'list',
+            'type': 'tuple',
             'itemsrules': {'type': ('string', 'number', 'dict')},
         }
     }

--- a/cerberus/tests/test_rule_items.py
+++ b/cerberus/tests/test_rule_items.py
@@ -12,7 +12,7 @@ def test_items(validator):
             field,
             (field, 'items'),
             errors.ITEMS,
-            [{'type': ('string',)}, {'type': ('integer',)}],
+            ({'type': ('string',)}, {'type': ('integer',)}),
         ),
         child_errors=[
             ((field, 1), (field, 'items', 1, 'type'), errors.TYPE, ('integer',))
@@ -35,7 +35,7 @@ def test_items_with_extra_item():
             field,
             (field, 'items'),
             errors.ITEMS_LENGTH,
-            [{'type': ('string',)}, {'type': ('integer',)}],
+            ({'type': ('string',)}, {'type': ('integer',)}),
             (2, 3),
         ),
     )

--- a/cerberus/tests/test_rule_items.py
+++ b/cerberus/tests/test_rule_items.py
@@ -12,15 +12,17 @@ def test_items(validator):
             field,
             (field, 'items'),
             errors.ITEMS,
-            [{'type': 'string'}, {'type': 'integer'}],
+            [{'type': ('string',)}, {'type': ('integer',)}],
         ),
         child_errors=[
-            ((field, 1), (field, 'items', 1, 'type'), errors.TYPE, 'integer')
+            ((field, 1), (field, 'items', 1, 'type'), errors.TYPE, ('integer',))
         ],
     )
 
     assert (
-        errors.BasicErrorHandler.messages[errors.TYPE.code].format(constraint='integer')
+        errors.BasicErrorHandler.messages[errors.TYPE.code].format(
+            constraint=('integer',)
+        )
         in validator.errors[field][-1][1]
     )
 
@@ -33,7 +35,7 @@ def test_items_with_extra_item():
             field,
             (field, 'items'),
             errors.ITEMS_LENGTH,
-            [{'type': 'string'}, {'type': 'integer'}],
+            [{'type': ('string',)}, {'type': ('integer',)}],
             (2, 3),
         ),
     )

--- a/cerberus/tests/test_rule_itemsrules.py
+++ b/cerberus/tests/test_rule_itemsrules.py
@@ -28,7 +28,7 @@ def test_itemsrules_with_schema(validator):
     assert 0 in validator.errors[field][-1]
     assert 'price' in validator.errors[field][-1][0][-1]
     exp_msg = errors.BasicErrorHandler.messages[errors.TYPE.code].format(
-        constraint='integer'
+        constraint=('integer',)
     )
     assert exp_msg in validator.errors[field][-1][0][-1]['price']
 
@@ -38,6 +38,6 @@ def test_itemsrules_with_schema(validator):
         document={field: ["not a dict"]},
         error=(field, (field, 'itemsrules'), errors.ITEMSRULES, itemsrules),
         child_errors=[
-            ((field, 0), (field, 'itemsrules', 'type'), errors.TYPE, 'dict', ())
+            ((field, 0), (field, 'itemsrules', 'type'), errors.TYPE, ('dict',), ())
         ],
     )

--- a/cerberus/tests/test_rule_schema.py
+++ b/cerberus/tests/test_rule_schema.py
@@ -31,7 +31,7 @@ def test_schema(validator):
                 (field, subschema_field),
                 (field, 'schema', subschema_field, 'type'),
                 errors.TYPE,
-                'string',
+                ('string',),
             ),
             (
                 (field, 'city'),
@@ -45,7 +45,9 @@ def test_schema(validator):
     assert field in validator.errors
     assert subschema_field in validator.errors[field][-1]
     assert (
-        errors.BasicErrorHandler.messages[errors.TYPE.code].format(constraint='string')
+        errors.BasicErrorHandler.messages[errors.TYPE.code].format(
+            constraint=('string',)
+        )
         in validator.errors[field][-1][subschema_field]
     )
     assert 'city' in validator.errors[field][-1]

--- a/cerberus/tests/test_rule_type.py
+++ b/cerberus/tests/test_rule_type.py
@@ -1,4 +1,5 @@
-from collections import abc
+from collections import abc, OrderedDict
+from datetime import date, datetime
 
 from pytest import mark
 
@@ -11,27 +12,59 @@ class SelfDefinedType:
 
 
 @mark.parametrize(
-    ("field", "_type", "value"),
+    ("_type", "value"),
     [
-        ('a_binary', 'binary', u"i'm not a binary"),
-        ('a_boolean', 'boolean', "i'm not a boolean"),
-        ('a_datetime', 'datetime', "i'm not a datetime"),
-        ('a_dict', 'dict', "i'm not a dict"),
-        ('a_float', 'float', "i'm not a float"),
-        ('an_integer', 'integer', "i'm not an integer"),
-        ('a_list_of_values', 'list', "i'm not a list"),
-        ('a_number', 'number', "i'm not a number"),
-        ('a_string', 'string', 1),
+        ("boolean", 0),
+        ("bytearray", b""),
+        ("bytes", ""),
+        ("complex", False),
+        ("date", datetime(year=1945, month=5, day=9, hour=0, minute=1)),
+        ("datetime", date(year=1945, month=5, day=9)),
+        ("dict", OrderedDict),
+        ("float", 1),
+        ("frozenset", set()),
+        ("integer", 0.1),
+        ("integer", False),
+        ("list", ()),
+        ("number", True),
+        ("set", frozenset()),
+        ("string", b""),
+        ("tuple", []),
+        ("type", 0),
     ],
 )
-def test_type_fails(field, _type, value):
+def test_type_fails(_type, value):
     assert_fail(
-        document={field: value}, error=(field, (field, 'type'), errors.TYPE, (_type,))
+        schema={"field": {"type": _type}},
+        document={"field": value},
+        error=("field", ("field", 'type'), errors.TYPE, (_type,)),
     )
 
 
-def test_type_succeeds():
-    assert_success(document={'a_set': {'hello', 1}})
+@mark.parametrize(
+    ("_type", "value"),
+    [
+        ("boolean", True),
+        ("bytearray", bytearray()),
+        ("bytes", b""),
+        ("complex", complex(1, -1)),
+        ("date", date(year=1945, month=5, day=9)),
+        ("datetime", datetime(year=1945, month=5, day=9, hour=0, minute=1)),
+        ("dict", {}),
+        ("float", 0.1),
+        ("frozenset", frozenset()),
+        ("integer", 0),
+        ("list", []),
+        ("number", 0),
+        ("number", 0.0),
+        ("set", set()),
+        ("string", ""),
+        ("tuple", ()),
+        ("type", int),
+    ],
+)
+def test_type_succeeds(_type, value):
+    assert_success(schema={"field": {"type": _type}}, document={"field": value})
 
 
 def test_type_skips_allowed():

--- a/cerberus/tests/test_rule_type.py
+++ b/cerberus/tests/test_rule_type.py
@@ -26,7 +26,7 @@ class SelfDefinedType:
 )
 def test_type_fails(field, _type, value):
     assert_fail(
-        document={field: value}, error=(field, (field, 'type'), errors.TYPE, _type)
+        document={field: value}, error=(field, (field, 'type'), errors.TYPE, (_type,))
     )
 
 
@@ -38,7 +38,7 @@ def test_type_skips_allowed():
     assert_fail(
         schema={'foo': {'type': 'string', 'allowed': ['a']}},
         document={'foo': 0},
-        error=('foo', ('foo', 'type'), errors.TYPE, 'string'),
+        error=('foo', ('foo', 'type'), errors.TYPE, ('string',)),
     )
 
 

--- a/cerberus/tests/test_rule_type.py
+++ b/cerberus/tests/test_rule_type.py
@@ -1,7 +1,13 @@
+from collections import abc
+
 from pytest import mark
 
 from cerberus import errors
 from cerberus.tests import assert_fail, assert_success
+
+
+class SelfDefinedType:
+    pass
 
 
 @mark.parametrize(
@@ -46,6 +52,23 @@ def test_type_skips_anyof():
         document={'part': 10},
     )
     assert len(_errors) == 1
+
+
+@mark.parametrize(
+    ("test_function", "constraint", "value"),
+    [
+        (assert_success, list, []),
+        (assert_success, abc.Sequence, []),
+        (assert_success, str, ""),
+        (assert_success, SelfDefinedType, SelfDefinedType()),
+        (assert_fail, list, ()),
+        (assert_fail, abc.Sequence, SelfDefinedType()),
+        (assert_fail, str, 1.0),
+        (assert_fail, SelfDefinedType, ""),
+    ],
+)
+def test_type_with_class_as_constraint(test_function, constraint, value):
+    test_function(schema={"field": {"type": constraint}}, document={"field": value})
 
 
 def test_boolean_is_not_a_number():

--- a/cerberus/tests/test_rule_type.py
+++ b/cerberus/tests/test_rule_type.py
@@ -1,10 +1,16 @@
 from collections import abc, OrderedDict
 from datetime import date, datetime
+from types import MappingProxyType
 
 from pytest import mark
 
 from cerberus import errors
 from cerberus.tests import assert_fail, assert_success
+
+
+class SelfDefinedContainer(abc.Container):
+    def __contains__(self, item):
+        pass
 
 
 class SelfDefinedType:
@@ -17,17 +23,30 @@ class SelfDefinedType:
         ("boolean", 0),
         ("bytearray", b""),
         ("bytes", ""),
+        ("ByteString", ""),
+        ("Callable", True),
         ("complex", False),
+        ("Container", 0),
         ("date", datetime(year=1945, month=5, day=9, hour=0, minute=1)),
         ("datetime", date(year=1945, month=5, day=9)),
         ("dict", OrderedDict),
         ("float", 1),
         ("frozenset", set()),
+        ("Hashable", []),
         ("integer", 0.1),
         ("integer", False),
+        ("Iterable", 0),
+        ("Iterator", []),
         ("list", ()),
+        ("Mapping", ((0, 1),)),
+        ("MutableMapping", MappingProxyType({})),
+        ("MutableSequence", ()),
+        ("MutableSet", frozenset()),
         ("number", True),
         ("set", frozenset()),
+        ("Set", ()),
+        ("Sequence", set()),
+        ("Sized", 0),
         ("string", b""),
         ("tuple", []),
         ("type", 0),
@@ -47,17 +66,32 @@ def test_type_fails(_type, value):
         ("boolean", True),
         ("bytearray", bytearray()),
         ("bytes", b""),
+        ("ByteString", b""),
+        ("Callable", assert_success),
         ("complex", complex(1, -1)),
+        ("Container", []),
+        ("Container", {}),
+        ("Container", SelfDefinedContainer()),
         ("date", date(year=1945, month=5, day=9)),
         ("datetime", datetime(year=1945, month=5, day=9, hour=0, minute=1)),
         ("dict", {}),
         ("float", 0.1),
         ("frozenset", frozenset()),
+        ("Hashable", 0),
         ("integer", 0),
+        ("Iterable", []),
+        ("Iterator", iter([])),
         ("list", []),
+        ("Mapping", {}),
+        ("MutableMapping", {}),
+        ("MutableSequence", []),
+        ("MutableSet", set()),
         ("number", 0),
         ("number", 0.0),
+        ("Sequence", ()),
         ("set", set()),
+        ("Set", frozenset()),
+        ("Sized", ()),
         ("string", ""),
         ("tuple", ()),
         ("type", int),

--- a/cerberus/tests/test_rule_valuesrules.py
+++ b/cerberus/tests/test_rule_valuesrules.py
@@ -16,14 +16,14 @@ def test_valuesrules_fails(validator):
             'a_dict_with_valuesrules',
             ('a_dict_with_valuesrules', 'valuesrules'),
             errors.VALUESRULES,
-            {'type': 'integer'},
+            {'type': ('integer',)},
         ),
         child_errors=[
             (
                 ('a_dict_with_valuesrules', 'a string'),
                 ('a_dict_with_valuesrules', 'valuesrules', 'type'),
                 errors.TYPE,
-                'integer',
+                ('integer',),
             )
         ],
     )

--- a/cerberus/tests/test_rule_…length.py
+++ b/cerberus/tests/test_rule_…length.py
@@ -53,7 +53,7 @@ def test_maxlength_fails(schema):
 
 
 def test_maxlength_with_bytestring_fails(schema):
-    field = 'a_binary'
+    field = 'a_bytestring'
     max_length = schema[field]['maxlength']
     value = b'\x00' * (max_length + 1)
     assert_fail(
@@ -85,7 +85,7 @@ def test_minlength_fails(schema):
 
 
 def test_minlength_with_bytestring_fails(schema):
-    field = 'a_binary'
+    field = 'a_bytestring'
     min_length = schema[field]['minlength']
     value = b'\x00' * (min_length - 1)
     assert_fail(

--- a/cerberus/tests/test_rule_…of.py
+++ b/cerberus/tests/test_rule_…of.py
@@ -24,7 +24,7 @@ def test_anyof_fails():
     assert_fail(
         document={'field': -1},
         schema=schema,
-        error=(('field',), ('field', 'anyof'), errors.ANYOF, [{'min': 0}, {'min': 10}]),
+        error=(('field',), ('field', 'anyof'), errors.ANYOF, ({'min': 0}, {'min': 10})),
         child_errors=[
             (('field',), ('field', 'anyof', 0, 'min'), errors.MIN_VALUE, 0),
             (('field',), ('field', 'anyof', 1, 'min'), errors.MIN_VALUE, 10),
@@ -91,10 +91,10 @@ def test_anyof_in_allof(test_function, document):
 def test_anyof_in_itemsrules(validator):
     # test that a list of schemas can be specified.
 
-    valid_parts = [
+    valid_parts = (
         {'schema': {'model number': {'type': 'string'}, 'count': {'type': 'integer'}}},
         {'schema': {'serial number': {'type': 'string'}, 'count': {'type': 'integer'}}},
-    ]
+    )
     valid_item = {'type': ['dict', 'string'], 'anyof': valid_parts}
     schema = {'parts': {'type': 'list', 'itemsrules': valid_item}}
     document = {
@@ -340,14 +340,14 @@ def test_allow_unknown_in_oneof():
     # https://github.com/pyeve/cerberus/issues/251
     schema = {
         'test': {
-            'oneof': [
+            'oneof': (
                 {
                     'type': 'dict',
                     'allow_unknown': True,
                     'schema': {'known': {'type': 'string'}},
                 },
                 {'type': 'dict', 'schema': {'known': {'type': 'string'}}},
-            ]
+            )
         }
     }
 

--- a/cerberus/tests/test_rule_…of.py
+++ b/cerberus/tests/test_rule_…of.py
@@ -14,7 +14,7 @@ from cerberus.tests import assert_fail, assert_not_has_error, assert_success
 )
 def test_allof(test_function, document):
     test_function(
-        schema={'field': {'allof': [{'type': 'float'}, {'min': 0}, {'max': 10}]}},
+        schema={'field': {'allof': [{'type': 'integer'}, {'min': 0}, {'max': 10}]}},
         document=document,
     )
 

--- a/cerberus/tests/test_rule_…of.py
+++ b/cerberus/tests/test_rule_…of.py
@@ -130,7 +130,7 @@ def test_anyof_in_itemsrules(validator):
                 ('parts', 4),
                 ('parts', 'itemsrules', 'type'),
                 errors.TYPE,
-                ['dict', 'string'],
+                ('dict', 'string'),
             ),
         ],
     )
@@ -152,7 +152,7 @@ def test_anyof_in_itemsrules(validator):
     assert 'anyof definition 1' in scope
     assert scope['anyof definition 0'] == [{"product name": ["unknown field"]}]
     assert scope['anyof definition 1'] == [{"product name": ["unknown field"]}]
-    assert _errors['parts'][-1][4] == ["must be of ['dict', 'string'] type"]
+    assert _errors['parts'][-1][4] == ["must be one of these types: ('dict', 'string')"]
 
 
 @mark.parametrize(
@@ -319,9 +319,11 @@ def test_oneof_type_in_oneof_schema(validator):
                                     'none or more than one rule validate',
                                     {
                                         'oneof definition 0': [
-                                            'must be of integer type'
+                                            "must be one of these types: ('integer',)"
                                         ],
-                                        'oneof definition 1': ['must be of float type'],
+                                        'oneof definition 1': [
+                                            "must be one of these " "types: ('float',)"
+                                        ],
                                     },
                                 ]
                             }

--- a/cerberus/tests/test_schema.py
+++ b/cerberus/tests/test_schema.py
@@ -33,7 +33,7 @@ def test_unknown_rule(validator):
 
 
 def test_unknown_type(validator):
-    msg = str({'foo': [{'type': ['Unsupported types: unknown']}]})
+    msg = str({'foo': [{'type': ['Unsupported type names: unknown']}]})
     with pytest.raises(SchemaError, match=re.escape(msg)):
         validator.schema = {'foo': {'type': 'unknown'}}
 

--- a/cerberus/tests/test_schema.py
+++ b/cerberus/tests/test_schema.py
@@ -33,14 +33,37 @@ def test_unknown_rule(validator):
 
 
 def test_unknown_type(validator):
-    msg = str({'foo': [{'type': ['Unsupported type names: unknown']}]})
+    msg = str(
+        {
+            'foo': [
+                {
+                    'type': [
+                        {
+                            0: [
+                                'none or more than one rule validate',
+                                {
+                                    'oneof definition 0': [
+                                        'Unsupported type name: unknown'
+                                    ],
+                                    'oneof definition 1': [
+                                        "must be one of these types: ('type',)"
+                                    ],
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+
     with pytest.raises(SchemaError, match=re.escape(msg)):
         validator.schema = {'foo': {'type': 'unknown'}}
 
 
 def test_bad_schema_definition(validator):
     field = 'name'
-    msg = str({field: ['must be of dict type']})
+    msg = str({field: ["must be one of these types: ('dict',)"]})
     with pytest.raises(SchemaError, match=re.escape(msg)):
         validator.schema = {field: 'this should really be a dict'}
 
@@ -71,7 +94,7 @@ def test_anyof_allof_schema_validate():
 
 def test_repr():
     v = Validator({'foo': {'type': 'string'}})
-    assert repr(v.schema) == "{'foo': {'type': 'string'}}"
+    assert repr(v.schema) == "{'foo': {'type': ('string',)}}"
 
 
 def test_expansion_in_nested_schema():
@@ -82,15 +105,14 @@ def test_expansion_in_nested_schema():
     }
 
 
-def test_anyof_check_with():
+def test_shortcut_expansion():
     def foo(field, value, error):
         pass
 
     def bar(field, value, error):
         pass
 
-    schema = {'field': {'anyof_check_with': [foo, bar]}}
-    validator = Validator(schema)
+    validator = Validator({'field': {'anyof_check_with': [foo, bar]}})
 
     assert validator.schema == {
         'field': {'anyof': [{'check_with': foo}, {'check_with': bar}]}

--- a/cerberus/tests/test_schema.py
+++ b/cerberus/tests/test_schema.py
@@ -46,7 +46,8 @@ def test_unknown_type(validator):
                                         'Unsupported type name: unknown'
                                     ],
                                     'oneof definition 1': [
-                                        "must be one of these types: ('type',)"
+                                        "must be one of these types: "
+                                        "('type', 'generic_type_alias')"
                                     ],
                                 },
                             ]
@@ -101,7 +102,7 @@ def test_expansion_in_nested_schema():
     schema = {'detroit': {'itemsrules': {'anyof_regex': ['^Aladdin', 'Sane$']}}}
     v = Validator(schema)
     assert v.schema['detroit']['itemsrules'] == {
-        'anyof': [{'regex': '^Aladdin'}, {'regex': 'Sane$'}]
+        'anyof': ({'regex': '^Aladdin'}, {'regex': 'Sane$'})
     }
 
 
@@ -115,7 +116,7 @@ def test_shortcut_expansion():
     validator = Validator({'field': {'anyof_check_with': [foo, bar]}})
 
     assert validator.schema == {
-        'field': {'anyof': [{'check_with': foo}, {'check_with': bar}]}
+        'field': {'anyof': ({'check_with': foo}, {'check_with': bar})}
     }
 
 

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -82,7 +82,6 @@ def test_validate_update():
     [
         {'a_boolean': True},
         {'a_datetime': datetime.now()},
-        {'a_float': 1},
         {'a_float': 3.5},
         {
             'a_list_of_dicts': [

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -47,11 +47,21 @@ def test_bad_valuesrules():
     value = {schema_field: 'not an integer'}
 
     exp_child_errors = [
-        ((field, schema_field), (field, 'valuesrules', 'type'), errors.TYPE, 'integer')
+        (
+            (field, schema_field),
+            (field, 'valuesrules', 'type'),
+            errors.TYPE,
+            ('integer',),
+        )
     ]
     assert_fail(
         {field: value},
-        error=(field, (field, 'valuesrules'), errors.VALUESRULES, {'type': 'integer'}),
+        error=(
+            field,
+            (field, 'valuesrules'),
+            errors.VALUESRULES,
+            {'type': ('integer',)},
+        ),
         child_errors=exp_child_errors,
     )
 
@@ -99,18 +109,20 @@ def test_one_of_two_types(validator):
     assert_success({field: 'foo'})
     assert_success({field: ['foo', 'bar']})
     exp_child_errors = [
-        ((field, 1), (field, 'itemsrules', 'type'), errors.TYPE, 'string')
+        ((field, 1), (field, 'itemsrules', 'type'), errors.TYPE, ('string',))
     ]
     assert_fail(
         {field: ['foo', 23]},
         validator=validator,
-        error=(field, (field, 'itemsrules'), errors.ITEMSRULES, {'type': 'string'}),
+        error=(field, (field, 'itemsrules'), errors.ITEMSRULES, {'type': ('string',)}),
         child_errors=exp_child_errors,
     )
     assert_fail(
-        {field: 23}, error=((field,), (field, 'type'), errors.TYPE, ['string', 'list'])
+        {field: 23}, error=((field,), (field, 'type'), errors.TYPE, ('string', 'list'))
     )
-    assert validator.errors == {field: [{1: ['must be of string type']}]}
+    assert validator.errors == {
+        field: [{1: ["must be one of these types: ('string',)"]}]
+    }
 
 
 def test_custom_validator():

--- a/cerberus/tests/test_zzz_validated_schema_cache.py
+++ b/cerberus/tests/test_zzz_validated_schema_cache.py
@@ -12,7 +12,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 390
+    max_cache_size = 403
     assert cache_size <= max_cache_size, (
         "There's an unexpected high amount (%s) of cached valid definition schemas. "
         "Unless you added further tests, there are good chances that something is "

--- a/cerberus/tests/test_zzz_validated_schema_cache.py
+++ b/cerberus/tests/test_zzz_validated_schema_cache.py
@@ -12,7 +12,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 370
+    max_cache_size = 374
     assert cache_size <= max_cache_size, (
         "There's an unexpected high amount (%s) of cached valid definition schemas. "
         "Unless you added further tests, there are good chances that something is "

--- a/cerberus/tests/test_zzz_validated_schema_cache.py
+++ b/cerberus/tests/test_zzz_validated_schema_cache.py
@@ -12,7 +12,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 403
+    max_cache_size = 424
     assert cache_size <= max_cache_size, (
         "There's an unexpected high amount (%s) of cached valid definition schemas. "
         "Unless you added further tests, there are good chances that something is "

--- a/cerberus/tests/test_zzz_validated_schema_cache.py
+++ b/cerberus/tests/test_zzz_validated_schema_cache.py
@@ -12,7 +12,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 374
+    max_cache_size = 390
     assert cache_size <= max_cache_size, (
         "There's an unexpected high amount (%s) of cached valid definition schemas. "
         "Unless you added further tests, there are good chances that something is "

--- a/cerberus/typing.py
+++ b/cerberus/typing.py
@@ -24,7 +24,8 @@ ErrorHandlerConfig = Union[
     Type['BaseErrorHandler'],
     Tuple[Type['BaseErrorHandler'], Mapping[str, Any]],
 ]
-RulesSet = Mapping[str, Any]
+NoneType = type(None)
+RulesSet = Dict[str, Any]
 SchemaDict = Mapping[FieldName, RulesSet]
 Schema = Union['ValidatedSchema', SchemaDict]
 AllowUnknown = Union[bool, RulesSet]

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -101,6 +101,6 @@ Examples
     >>> error.rule
     'type'
     >>> error.constraint
-    'integer'
+    ('integer',)
     >>> error.value
     'two'

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -107,7 +107,7 @@ unknown fields will be validated against it:
     >>> v.validate({'an_unknown_field': 1})
     False
     >>> v.errors
-    {'an_unknown_field': ['must be of string type']}
+    {'an_unknown_field': ["must be one of these types: ('string',)"]}
 
 ``allow_unknown`` can also be set at initialization:
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -751,7 +751,9 @@ as constraint.
 
 type
 ----
-Data type allowed for the key value. Can be one of the following names:
+Tests whether the field value's type matches the specified type. That
+specification can either be a class or one of the following names given as
+string:
 
 .. list-table::
    :header-rows: 1
@@ -759,27 +761,29 @@ Data type allowed for the key value. Can be one of the following names:
    * - Type Name
      - Python Type
    * - ``boolean``
-     - :class:`pybool`
+     - :class:`bool`
    * - ``binary``
-     - :class:`pybytes`, :class:`pybytearray`
+     - :class:`bytes`, :class:`bytearray`
    * - ``date``
-     - :class:`pydatetime.date`
+     - :class:`datetime.date`
    * - ``datetime``
-     - :class:`pydatetime.datetime`
+     - :class:`datetime.datetime`
    * - ``dict``
-     - :class:`pycollections.abc.Mapping`
+     - :class:`collections.abc.Mapping`
    * - ``float``
-     - :class:`pyfloat`
+     - :class:`float`
    * - ``integer``
-     - :class:`pyint`
+     - :class:`int`
    * - ``list``
-     - :class:`pycollections.abc.Sequence`, excl. ``string``
+     - :class:`collections.abc.Sequence`, excl. ``string``
    * - ``number``
-     - :class:`pyfloat`, :class:`pyint`, excl. :class:`pybool`
+     - :class:`float`, :class:`pyint`, excl. :class:`pybool`
    * - ``set``
-     - :class:`pyset`
+     - :class:`set`
    * - ``string``
-     - :class:`pystr`
+     - :class:`str`
+   * - ``type``
+     - :class:`type` (classes)
 
 You can extend this list and support :ref:`custom types <new-types>`.
 
@@ -787,7 +791,7 @@ A list of types can be used to allow different values:
 
 .. doctest::
 
-    >>> v.schema = {'quotes': {'type': ['string', 'list']}}
+    >>> v.schema = {'quotes': {'type': ['string', list]}}
     >>> v.validate({'quotes': 'Hello world!'})
     True
     >>> v.validate({'quotes': ['Do not disturb my circles!', 'Heureka!']})

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -807,7 +807,8 @@ A list of types can be used to allow different values:
     >>> v.validate({'quotes': [1, 'Heureka!']})
     False
     >>> v.errors
-    {'quotes': [{0: ['must be of string type']}]}
+    {'quotes': [{0: ["must be one of these types: ('string',)"]}]}
+
 
 .. note::
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -762,26 +762,34 @@ string:
      - Python Type
    * - ``boolean``
      - :class:`bool`
-   * - ``binary``
-     - :class:`bytes`, :class:`bytearray`
+   * - ``bytesarray``
+     - :class:`bytearray`
+   * - ``bytes``
+     - :class:`bytes`
+   * - ``complex``
+     - :class:`complex`
    * - ``date``
-     - :class:`datetime.date`
+     - :class:`datetime.date`, but not its subclass :class:`datetime.datetime`
    * - ``datetime``
      - :class:`datetime.datetime`
    * - ``dict``
-     - :class:`collections.abc.Mapping`
+     - :class:`dict`
    * - ``float``
      - :class:`float`
+   * - ``frozenset``
+     - :class:`frozenset`
    * - ``integer``
-     - :class:`int`
+     - :class:`int`, but not its subclass :class:`bool`
    * - ``list``
-     - :class:`collections.abc.Sequence`, excl. ``string``
+     - :class:`list`
    * - ``number``
-     - :class:`float`, :class:`pyint`, excl. :class:`pybool`
+     - :class:`float`, :class:`int`, but not  :class:`bool`
    * - ``set``
      - :class:`set`
    * - ``string``
      - :class:`str`
+   * - ``tuple``
+     - :class:`tuple`
    * - ``type``
      - :class:`type` (classes)
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -751,9 +751,14 @@ as constraint.
 
 type
 ----
-Tests whether the field value's type matches the specified type. That
-specification can either be a class or one of the following names given as
-string:
+Tests whether the field value's type matches the specified type. A single
+specification can either be a class, one of the names (as string) that strictly
+map to one type documented in the following table or a name of the abstract
+types from the :mod:`collections.abc` module. Note that the extent of the
+latter depends on the used Python version and the names are camel-cased (e.g.
+``Set`` or ``MutableMapping``). Named types allow the serialization of schemas
+and the exclusion of particular subtypes. You can also extend the named types
+to support :ref:`custom types <new-types>`.
 
 .. list-table::
    :header-rows: 1
@@ -793,9 +798,25 @@ string:
    * - ``type``
      - :class:`type` (classes)
 
-You can extend this list and support :ref:`custom types <new-types>`.
+Here are examples of the different ways to specify a type:
 
-A list of types can be used to allow different values:
+.. doctest::
+
+    >>> document = {"items": frozenset("a", "b", "c")}
+    >>> v.schema = {"items": {"type": frozenset}}  # class-based test
+    >>> v.validate(document)
+    True
+    >>> v.schema = {"items": {"type": 'frozenset'}}  # named concrete type
+    >>> v.validate(document)
+    True
+    >>> v.schema = {"items": {"type": 'set'}}  # also a named concrete type
+    >>> v.validate(document)
+    False
+    >>> v.schema = {"items": {"type": 'Set'}}  # named abstract type
+    >>> v.validate(document)
+    True
+
+A list of types can be used to allow different values of different types:
 
 .. doctest::
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py35,py36,py37,pypy3,doclinks,doctest,linting,mypy
+envlist=py35,py36,py37,py38,pypy3,doclinks,doctest,linting,mypy
 
 [testenv]
 deps=pytest

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,9 @@ commands=pre-commit run --config .linting-config.yaml --all-files
 
 [testenv:mypy]
 deps = mypy
-commands = mypy cerberus
+commands =
+     mypy --version
+     mypy cerberus
 whitelist_externals = mypy
 
 


### PR DESCRIPTION
this implements the proposals in #374 and adds a conversion of generic type aliases to constraints for the type rule that will be necessary to implement dataclass validation (#397). please see the changed docs for details on the features.

some notes on the pr:

- sits on top of the changes from #497
- there are some `TODO`s regarding schema normalization that are not in the scope of types and shall be solved later
- the upgrading guide isn't updated, i prefer to do that when all changes for a new release are merged