### PR TITLE
Add maxlength minlength examples

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,10 +55,10 @@ Contributors
 - Sergey Leshchenko
 - Tobias Betz
 - Trong Hieu HA
+- Vipul Gupta
 - Waldir Pimenta
 - calve
 - gilbsgilbs
-- Vipul Gupta
 
 A full, up-to-date list of contributors is available from git with:
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Contributors
 - Waldir Pimenta
 - calve
 - gilbsgilbs
+- Vipul Gupta
 
 A full, up-to-date list of contributors is available from git with:
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -444,7 +444,8 @@ The assigned data can be of any type.
 min, max
 --------
 
-Minimum and maximum value allowed for any types that implement comparison operators.
+Minimum and maximum value allowed for any types that implement comparison operators. See
+`\*of-rules`_ for examples.
 
 .. versionchanged:: 1.0
   Allows any type to be compared.
@@ -456,6 +457,22 @@ minlength, maxlength
 --------------------
 
 Minimum and maximum length allowed for iterables.
+
+.. doctest::
+
+    >>> schema = {'numbers': {'type': 'list', 'minlength': 1, 'maxlength': 3}}
+    >>> document = {'numbers': [256, 2048, 23]}
+
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'numbers': [256, 2048, 23, 2]}
+    >>> v.validate(document, schema)
+    False
+
+    >>> v.errors
+    >>> {'numbers': ['max length is 3']}
+
 
 noneof
 ------

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -447,6 +447,21 @@ min, max
 Minimum and maximum value allowed for any types that implement comparison operators. See
 `\*of-rules`_ for examples.
 
+.. doctest::
+
+    >>> schema = {'weight':{'type':'float', 'min': 10.1,'max':10.9}}
+    >>> document = {'weight': 10.3}
+
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'weight': 12}
+    >>> v.validate(document, schema)
+    False
+
+    >>> v.errors
+    {'weight': ['max value is 10.9']}
+
 .. versionchanged:: 1.0
   Allows any type to be compared.
 
@@ -456,7 +471,7 @@ Minimum and maximum value allowed for any types that implement comparison operat
 minlength, maxlength
 --------------------
 
-Minimum and maximum length allowed for iterables.
+Minimum and maximum length allowed for any objects that implements __len__. Examples are as follows:
 
 .. doctest::
 
@@ -471,7 +486,7 @@ Minimum and maximum length allowed for iterables.
     False
 
     >>> v.errors
-    >>> {'numbers': ['max length is 3']}
+    {'numbers': ['max length is 3']}
 
 
 noneof


### PR DESCRIPTION
:hatching_chick: 
Added missing examples for `maxlength` and `minlength` validation rules to the docs in accordance with #500, let me know if there are any more examples that you like to see. Or improve any examples. Would be happy to write and contribute to the docs. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>