### PR TITLE
Add python 3.7 in the supported version in the index page of the documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Welcome to Cerberus
 Cerberus provides powerful yet simple and lightweight data validation
 functionality out of the box and is designed to be easily extensible, allowing
 for custom validation. It has no dependencies and is thoroughly tested
-from Python 2.7 up to 3.6, PyPy and PyPy3.
+from Python 2.7 up to 3.7, PyPy and PyPy3.
 
 At a Glance
 -----------


### PR DESCRIPTION
In the index file of the documentation, add the python 3.7 as maximum supported version.