### PR TITLE
conditional normalization using oneof 

### DIFF
--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -553,8 +553,9 @@ according to the prefixes logics ``all``, ``any``, ``one`` or ``none``.
 
 .. note::
 
-    :doc:`Normalization <normalization-rules>` cannot be used in the rule sets
-    within the constraints of these rules.
+    :doc:`Normalization <normalization-rules>` can only be used with ``oneof``. 
+    They cannot be used in the rule sets within the constraints of ``allof``,
+     ``anyof`` or ``noneof`  rules.
 
 .. note::
 


### PR DESCRIPTION
I am not sure if I found the good entry-point to implement #515 but it certainly illustrates a possible path that could be taken to allow for  conditional normalization.

An open todo is in the schema of `_validate_oneof` where "'logical': 'oneof'" can no longer be used as it doesn't allow the `default` rule.