### PR TITLE
Fix documentation warnings and build instruction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ _build
 # Jetbrains
 .idea
 .vscode/
+.devcontainer/

--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -37,6 +37,7 @@ def validator_factory(
     """ Dynamically create a :class:`~cerberus.Validator` subclass.
         Docstrings of mixin-classes will be added to the resulting
         class' one if ``__doc__`` is not in :obj:`namespace`.
+
     :param name: The name of the new class.
     :param bases: Class(es) with additional and overriding attributes.
     :param namespace: Attributes for the new class.

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -177,8 +177,8 @@ class ValidationError:
 
     @property
     def definitions_errors(self) -> Optional[DefaultDict[int, "ErrorList"]]:
-        """
-        Dictionary with errors of an *of-rule mapped to the index of the definition it
+        r"""
+        Dictionary with errors of an \*of-rule mapped to the index of the definition it
         occurred in. Returns :obj:`None` if not applicable.
         """
         if not self.is_logic_error:
@@ -205,8 +205,8 @@ class ValidationError:
 
     @property
     def is_logic_error(self) -> bool:
-        """ ``True`` for validation errors against different schemas with
-            *of-rules. """
+        r""" ``True`` for validation errors against different schemas with
+            \*of-rules. """
         return bool(self.code & LOGICAL.code - ERROR_GROUP.code)
 
     @property

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -70,11 +70,11 @@ Some codes are actually reserved to mark a shared property of different errors.
 These are useful as bitmasks while processing errors. This is the list of the
 reserved codes:
 
-============= ======== === ==================================================
+============= ======== === ===================================================
 ``0110 0000`` ``0x60``  96 An error that occurred during normalization.
 ``1000 0000`` ``0x80`` 128 An error that contains child errors.
-``1001 0000`` ``0x90`` 144 An error that was emitted by one of the *of-rules.
-============= ======== === ==================================================
+``1001 0000`` ``0x90`` 144 An error that was emitted by one of the \*of-rules.
+============= ======== === ===================================================
 
 None of these bits in the upper nibble must be used to enumerate error
 definitions, but only to mark one with the associated property.

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -85,8 +85,8 @@ documentation framework and a theme:
 
 .. code-block:: console
 
-    $ # in the project's root directory
-    $ pip install -r requirements-docs.txt
+    $ # in 'docs'-folder
+    $ pip install -r requirements.txt
 
 The HTML build is triggered with:
 


### PR DESCRIPTION
Hello!

I followed all steps from the contribution guide and found there is no requirements-docs.txt file in docs folder. Also I propose fixes for documentation warnings and empty link on * sign.