### PR TITLE
Backport docstring invalid syntax fixes

### DIFF
--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -154,7 +154,7 @@ class ValidationError(object):
     @property
     def definitions_errors(self):
         """
-        Dictionary with errors of an \*of-rule mapped to the index of the definition it
+        Dictionary with errors of an *of-rule mapped to the index of the definition it
         occurred in. Returns :obj:`None` if not applicable.
         """
         if not self.is_logic_error:
@@ -182,7 +182,7 @@ class ValidationError(object):
     @property
     def is_logic_error(self):
         """
-        ``True`` for validation errors against different schemas with \*of-rules.
+        ``True`` for validation errors against different schemas with *of-rules.
         """
         return bool(self.code & LOGICAL.code - ERROR_GROUP.code)
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ commands=pre-commit run --config .linting-config.yaml --all-files
 
 [flake8]
 max-line-length=88
-ignore=E203,W503,W605
+ignore=E203,W503


### PR DESCRIPTION
Backport these fixed in order to avoid runtime errors with newer python versions.

Fixes: #568