### PR TITLE
WIP: Re-enabling tests for Python3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,10 @@ envlist=py27,py34,py35,py36,py37,py38,py39,pypy,pypy3,doclinks,doctest,linting
 deps=pytest
 commands=pytest cerberus/tests
 
+[testenv:py34]
+deps=pytest
+     attrs==20.3.0
+
 [testenv:doclinks]
 deps=-rdocs/requirements.txt
 whitelist_externals=make


### PR DESCRIPTION
this is my first approach to re-enable tests for Python 3.4. i'm sparse with time, so i would appreciate if anyone could investigate this issue further or come up with other proposals. here are some noteworthy facts:

- the Cerberus 1.3 line aims to support all releases that its initial release and the following did
- the last pytest release for Python 3.4 was 4.6
- the pytest 4.6.11 release declares `attrs>=17.40` as dependency
- the last attrs release that supported Python 3.4 was 20.3.0
- but pip resolves the dependency to 21.1.0 (though it has been yanked and a newer release is available)

hence i tried to replicate what is possible on the command line: `pip install pytest && pip install attrs==20.3.0`, but tox / pip don't seem to consider the version constraint.