### PR TITLE
decrease memory consumption, use importlib.metadata to get package version instead of pkg_resources.get_dictribution

### DIFF
--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -8,7 +8,6 @@
 
 """
 
-import sys
 from typing import Dict, Optional, Tuple, Union
 
 from cerberus.base import (
@@ -21,15 +20,15 @@ from cerberus.base import (
 from cerberus.schema import SchemaError
 from cerberus.validator import Validator
 
-if sys.version_info >= (3, 8, 0):
-    from importlib.metadata import version
-    __version__ = version("Cerberus")
-else:
-    from pkg_resources import get_distribution, DistributionNotFound
-    try:
-        __version__ = get_distribution("Cerberus").version
-    except DistributionNotFound:
-        __version__ = "unknown"
+
+try:
+    # Python 3.8+
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # <Python 3.7 and lower
+    import importlib_metadata
+
+__version__ = importlib_metadata.version("Cerberus")
 
 
 def validator_factory(

--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -20,13 +20,7 @@ from cerberus.base import (
 from cerberus.schema import SchemaError
 from cerberus.validator import Validator
 
-
-try:
-    # Python 3.8+
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # <Python 3.7 and lower
-    import importlib_metadata
+from cerberus.platform import importlib_metadata
 
 __version__ = importlib_metadata.version("Cerberus")
 

--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -8,7 +8,7 @@
 
 """
 
-from pkg_resources import get_distribution, DistributionNotFound
+import sys
 from typing import Dict, Optional, Tuple, Union
 
 from cerberus.base import (
@@ -21,11 +21,15 @@ from cerberus.base import (
 from cerberus.schema import SchemaError
 from cerberus.validator import Validator
 
-
-try:
-    __version__ = get_distribution("Cerberus").version
-except DistributionNotFound:
-    __version__ = "unknown"
+if sys.version_info >= (3, 8, 0):
+    from importlib.metadata import version
+    __version__ = version("Cerberus")
+else:
+    from pkg_resources import get_distribution, DistributionNotFound
+    try:
+        __version__ = get_distribution("Cerberus").version
+    except DistributionNotFound:
+        __version__ = "unknown"
 
 
 def validator_factory(

--- a/cerberus/platform.py
+++ b/cerberus/platform.py
@@ -4,6 +4,7 @@ import sys
 
 
 if sys.version_info < (3, 7):
+    import importlib_metadata
     from typing import _ForwardRef as ForwardRef, GenericMeta as GenericAlias
     from typing import _Union, Union
 
@@ -24,6 +25,7 @@ if sys.version_info < (3, 7):
 
 
 elif sys.version_info < (3, 8):
+    import importlib_metadata
     from typing import ForwardRef, _GenericAlias as GenericAlias
 
     def get_type_args(tp):
@@ -41,6 +43,7 @@ elif sys.version_info < (3, 8):
 
 
 elif sys.version_info < (3, 9):
+    import importlib.metadata as importlib_metadata
     from typing import ForwardRef, _GenericAlias as GenericAlias  # type: ignore
     from typing import get_args as get_type_args
     from typing import get_origin as get_type_origin
@@ -50,6 +53,7 @@ elif sys.version_info < (3, 9):
 
 
 else:
+    import importlib.metadata as importlib_metadata
     from typing import ForwardRef, _BaseGenericAlias as GenericAlias
     from typing import get_args as get_type_args
     from typing import get_origin as get_type_origin

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,10 @@ setup(
     setup_requires=setup_requires,
     tests_require=["pytest"],
     test_suite="cerberus.tests",
-    install_requires=["setuptools"],
+    install_requires=[
+        "setuptools",
+        "importlib-metadata; python_version < '3.8'",
+    ],
     keywords=["validation", "schema", "dictionaries", "documents", "normalization"],
     python_requires=">=3.5",
     classifiers=[


### PR DESCRIPTION
pkg_resources use a lot of memory and after introducing importlib.metadata in 3.8 looks obsolete. So let's change way to get package version and get rid of pkg_resources import. 