### PR TITLE
Note about Validator thread-safety

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -5,3 +5,13 @@ Can I use Cerberus to validate objects?
 ---------------------------------------
 
 Yes. See `Validating user objects with Cerberus <https://nicolaiarocci.com/validating-user-objects-cerberus/>`_.
+
+Are Cerberus validators thread-safe, can they be used in different threads?
+---------------------------------------------------------------------------
+
+The `validate*` methods of Cerberus validators make a copy of the document
+being validated and store it internally. Because of this it is advised to
+create a new validator object for each document you will be validating when
+used in a multi-threaded context. Alternatively you can use a `threading.Lock`
+to confirm that only one `validate` (or `validated`) call is running at any
+given time.


### PR DESCRIPTION
the `validate*` methods of a validator makes a copy of the document being
validated and rely on that document not changing during validation.
When used in a multi-threaded context with a global validator object 
(such as in a webserver or a REST api), it is possible for the document to change
while the validation is taking place which causes seemingly random errors.
This note helps users understand that validators are not thread safe.