### PR TITLE
Fix: Skip *of_schema rules on nullable fields that are null.

### DIFF
--- a/cerberus/base.py
+++ b/cerberus/base.py
@@ -1766,7 +1766,9 @@ class UnconcernedValidator(metaclass=ValidatorMeta):
             if not (nullable or self.ignore_none_values):
                 self._error(field, errors.NULLABLE)
             self._drop_remaining_rules(
+                'allof',
                 'allowed',
+                'anyof',
                 'empty',
                 'forbidden',
                 'items',
@@ -1775,6 +1777,8 @@ class UnconcernedValidator(metaclass=ValidatorMeta):
                 'max',
                 'minlength',
                 'maxlength',
+                'noneof',
+                'oneof',
                 'regex',
                 'schema',
                 'type',

--- a/cerberus/tests/test_rule_nullable.py
+++ b/cerberus/tests/test_rule_nullable.py
@@ -49,3 +49,55 @@ def test_nullable_skips_allowed():
 def test_nullable_skips_type(validator):
     assert_fail({'an_integer': None}, validator=validator)
     assert validator.errors == {'an_integer': ['null value not allowed']}
+
+
+def test_nullable_skips_allof_schema():
+    assert_success(
+        schema={
+            'foo': {
+                'type': 'dict',
+                'nullable': True,
+                'allof_schema': [{'bar': {'type': 'string'}}],
+            }
+        },
+        document={'foo': None},
+    )
+
+
+def test_nullable_skips_anyof_schema():
+    assert_success(
+        schema={
+            'foo': {
+                'type': 'dict',
+                'nullable': True,
+                'anyof_schema': [{'bar': {'type': 'string'}}],
+            }
+        },
+        document={'foo': None},
+    )
+
+
+def test_nullable_skips_noneof_schema():
+    assert_success(
+        schema={
+            'foo': {
+                'type': 'dict',
+                'nullable': True,
+                'noneof_schema': [{'bar': {'type': 'string'}}],
+            }
+        },
+        document={'foo': None},
+    )
+
+
+def test_nullable_skips_oneof_schema():
+    assert_success(
+        schema={
+            'foo': {
+                'type': 'dict',
+                'nullable': True,
+                'oneof_schema': [{'bar': {'type': 'string'}}],
+            }
+        },
+        document={'foo': None},
+    )


### PR DESCRIPTION
Resolves issue #582 by skipping the *of_schema rules when a nullable field is set to None.