### PR TITLE
Feature #444 - Document level validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # mind that a similar file exists for linting usage
 repos:
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 22.12.0
     hooks:
       - id: black
         args: [--quiet]

--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ Contributors
 - Martin Ortbauer
 - Matthew Ellison
 - Michael Klich
+- Michael Ottoson
 - Nik Haldimann
 - Nikita Melentev
 - Nikita Vlaznev

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ In Development
 
 New
 ~~~
-
+- Document level validation (`#444`_)
 - Classes can be used as constraint for the ``type`` rule (`#374`_)
 - The abstract base classes of the standard library's ``collections.abc``
   module are available as named types for the ``type`` rule (`#374`_)
@@ -31,6 +31,7 @@ Fixed
 - WARNING Unexpected keys present on Black: python_version (`#494`_)
 
 .. _`#494`: https://github.com/pyeve/cerberus/issues/494
+.. _`#444`: https://github.com/pyeve/cerberus/issues/444
 .. _`#374`: https://github.com/pyeve/cerberus/issues/374
 
 Version 1.3.4


### PR DESCRIPTION
With this PR you can create document level validations - i.e. validations not attached to a field, but to the document so that it can consider multiple fields at once.

For example, a drink order is invalid if 1) it includes an alcoholic beverage and 2) the customer's age is below the allowed drinking age.  To accomplish this with document level validations:


```
    class MyValidator(Validator):
        def _validate_document_allowed_drinking_age(self, allowed_drinking_age):
            """ Ensure only those of allowed drinking age or older can order alcohol

            The rule's arguments are validated against this schema:
            {'type': 'integer'}
            """
            if not allowed_drinking_age:
                return
            is_valid = True
            beverage = self.document.get('beverage')
            age = self.document.get('customer_age', 0)
            if beverage in ['beer', 'wine']:
                is_valid = age >= allowed_drinking_age
            if not is_valid:
                self._error('_document', f'Invalid order: Cannot order {beverage} at age {age} (must be {allowed_drinking_age} or over)')


```
    >>> schema = {'beverage': {'type': 'string', 'allowed': ['beer', 'wine', 'water', 'soda']},'customer_age': {'type': 'integer'}}
    >>> v = MyValidator(schema, document_validations={'allowed_drinking_age': 21})
    >>> v.validate({'beverage': 'beer', 'customer_age': 22})
    True
    >>> v.validate({'beverage': 'soda', 'customer_age': 10})
    True
    >>> v.validate({'beverage': 'beer', 'customer_age': 12})
    False
    >>>v.errors
    {'_document': ['Invalid order: Cannot order beer at age 12 (must be 21 or over)']}

```
