### PR TITLE
Proper escaping

### DIFF
--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -155,7 +155,7 @@ class ValidationError(object):
     @property
     def definitions_errors(self):
         """
-        Dictionary with errors of an \*of-rule mapped to the index of the definition it
+        Dictionary with errors of an \\*of-rule mapped to the index of the definition it
         occurred in. Returns :obj:`None` if not applicable.
         """
         if not self.is_logic_error:
@@ -183,7 +183,7 @@ class ValidationError(object):
     @property
     def is_logic_error(self):
         """
-        ``True`` for validation errors against different schemas with \*of-rules.
+        ``True`` for validation errors against different schemas with \\*of-rules.
         """
         return bool(self.code & LOGICAL.code - ERROR_GROUP.code)
 


### PR DESCRIPTION
Get rid of `DeprecationWarning: invalid escape sequence \*`