### PR TITLE
fix: align _validate_allowed type check with _validate_forbidden

### DIFF
--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -2003,6 +2003,40 @@ def test_allowed_when_passing_list_of_dicts():
     )
 
 
+def test_allowed_consistency_with_forbidden_for_dict_values():
+    # _validate_allowed used Iterable (which includes Mapping) while
+    # _validate_forbidden used Sequence (which excludes Mapping).
+    # This caused 'allowed' to iterate over dict keys instead of checking
+    # the dict as a single value, inconsistent with 'forbidden'.
+    schema_allowed = {'field': {'allowed': [{'key': 'val'}]}}
+    schema_forbidden = {'field': {'forbidden': [{'key': 'val'}]}}
+
+    # With the fix, allowed checks dict as a whole (matching forbidden)
+    assert_success({'field': {'key': 'val'}}, schema_allowed)
+    assert_fail({'field': {'key': 'val'}}, schema_forbidden)
+
+    # allowed should still reject a dict not in the list
+    assert_fail({'field': {'other': 'val'}}, schema_allowed)
+
+    # allowed should still check sequence elements individually
+    assert_success({'field': [1, 2]}, {'field': {'allowed': [1, 2, 3]}})
+    assert_fail(
+        {'field': [1, 4]},
+        {'field': {'allowed': [1, 2, 3]}},
+        error=(
+            'field',
+            ('field', 'allowed'),
+            errors.UNALLOWED_VALUES,
+            [1, 2, 3],
+            ((4,),),
+        ),
+    )
+
+    # forbidden should still check sequence elements individually
+    assert_success({'field': [4, 5]}, {'field': {'forbidden': [1, 2, 3]}})
+    assert_fail({'field': [1, 4]}, {'field': {'forbidden': [1, 2, 3]}})
+
+
 def test_schema_validation_from_rules_set():
     # https://github.com/pyeve/cerberus/issues/599
     rules_set_registry.add(

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -1127,7 +1127,7 @@ class BareValidator(object):
 
     def _validate_allowed(self, allowed_values, field, value):
         """{'type': 'container'}"""
-        if isinstance(value, Iterable) and not isinstance(value, _str_type):
+        if isinstance(value, Sequence) and not isinstance(value, _str_type):
             unallowed = tuple(x for x in value if x not in allowed_values)
             if unallowed:
                 self._error(field, errors.UNALLOWED_VALUES, unallowed)


### PR DESCRIPTION
## Problem

`_validate_allowed` used `Iterable` for its instance check while `_validate_forbidden` used `Sequence`. Since `Mapping` (dict) is an `Iterable` but not a `Sequence`, this caused inconsistent behavior:

- `allowed: [{"key": "val"}]` with value `{"key": "val"}`: iterated over dict *keys*, found "key" not in `[{"key": "val"}]`, and incorrectly rejected the value.
- `forbidden: [{"key": "val"}]` with value `{"key": "val"}`: correctly checked the dict as a whole value.

## Fix

Changed `_validate_allowed` from using `Iterable` to `Sequence` (matching `_validate_forbidden`), so both rules treat dict and set values as single values and only iterate over sequence elements.

## Changes

- `cerberus/validator.py`: one line changed (`Iterable` -> `Sequence` in `_validate_allowed`)
- `cerberus/tests/test_validation.py`: added test covering the inconsistency