### PR TITLE
Report type error for a mapping given to a list schema (fixes #545)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Contributors
 - Peter Demin
 - Riccardo
 - Roman Redkovich
+- Sanjay Santhanam
 - Scott Crunkleton
 - Sebastian Heid
 - Sebastian Rajo

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Cerberus Changelog
 ==================
 
+Unreleased
+----------
+
+Fixed
+~~~~~
+
+- Report a type error instead of raising ``TypeError`` when a mapping is
+  provided for a field declared as a ``list`` with an item ``schema``
+  (`#545`_)
+
+.. _`#545`: https://github.com/pyeve/cerberus/issues/545
+
+
 Version 1.3.8
 -------------
 

--- a/cerberus/tests/test_normalization.py
+++ b/cerberus/tests/test_normalization.py
@@ -438,6 +438,56 @@ def test_issue_250_no_type_fail_pass_on_other():
     assert_normalized(document, document, schema)
 
 
+def test_mapping_for_list_schema_reports_type_error():
+    # https://github.com/pyeve/cerberus/issues/545
+    # A mapping supplied where a list with an item schema is expected used to
+    # raise a bare TypeError during the rename normalization step (the item
+    # schema was resolved against the mapping's keys, yielding None rules sets).
+    # It must instead report the field as being of the wrong type.
+    schema = {
+        'list': {
+            'type': 'list',
+            'schema': {'type': 'dict', 'schema': {'width': {'type': 'integer'}}},
+        }
+    }
+    document = {'list': {'type': 'error'}}
+    assert_fail(
+        document,
+        schema,
+        error=('list', ('list', 'type'), errors.BAD_TYPE, schema['list']['type']),
+    )
+
+
+def test_mapping_for_nested_list_schema_reports_type_error():
+    # https://github.com/pyeve/cerberus/issues/545
+    # The reporter's original, deeply nested reproduction.
+    schema = {
+        'metadata': {
+            'type': 'dict',
+            'nullable': True,
+            'schema': {
+                'image_thumb': {
+                    'type': 'list',
+                    'required': False,
+                    'default': [],
+                    'minlength': 0,
+                    'maxlength': 10,
+                    'schema': {
+                        'type': 'dict',
+                        'default': None,
+                        'nullable': True,
+                        'schema': {'width': {'type': 'integer', 'required': True}},
+                    },
+                }
+            },
+        }
+    }
+    document = {'metadata': {'image_thumb': {'type': 'error'}}}
+    validator = Validator(schema)
+    assert validator.validate(document) is False
+    assert validator.errors == {'metadata': [{'image_thumb': ['must be of list type']}]}
+
+
 def test_allow_unknown_with_of_rules():
     # https://github.com/pyeve/cerberus/issues/251
     schema = {

--- a/cerberus/tests/test_schema.py
+++ b/cerberus/tests/test_schema.py
@@ -88,7 +88,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 163
+    max_cache_size = 170
     assert cache_size <= max_cache_size, (
         "There's an unexpected high amount (%s) of cached valid "
         "definition schemas. Unless you added further tests, "

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -900,6 +900,8 @@ class BareValidator(object):
     def __normalize_rename_fields(self, mapping, schema):
         for field in tuple(mapping):
             if field in schema:
+                if schema[field] is None:
+                    raise _SchemaRuleTypeError
                 self._normalize_rename(mapping, schema, field)
                 self._normalize_rename_handler(mapping, schema, field)
             elif (


### PR DESCRIPTION
## Summary

Fixes #545.

When a mapping is supplied for a field declared as a `list` with an item `schema`, `cerberus` crashes during normalization with a bare `TypeError` instead of reporting the value as being of the wrong type.

```python
from cerberus import Validator

schema = {
    'list': {
        'type': 'list',
        'schema': {'type': 'dict', 'schema': {'width': {'type': 'integer'}}},
    }
}
Validator(schema).validate({'list': {'type': 'error'}})
# TypeError: argument of type 'NoneType' is not iterable
```

The reporter's original (nested) reproduction hits the same crash.

## Root cause

To normalize a list's items, the item schema is resolved against the supplied value. When that value is a **mapping** (rather than the expected list), the item schema is looked up per mapping key, so keys that are not part of the item schema resolve to a `None` rules set.

Sibling normalization steps already anticipate this conflation of a list item schema with a mapping and raise `_SchemaRuleTypeError` — which is caught at the child-validator boundary in `__normalize_containers` (`except _SchemaRuleTypeError: pass`) so the mismatch surfaces as an ordinary type error. See `__normalize_default_fields`:

```python
try:
    fields_with_default = [x for x in empty_fields if 'default' in schema[x]]
except TypeError:
    raise _SchemaRuleTypeError
```

and `_validate_required_fields` (which raises `_SchemaRuleTypeError` on the same condition).

`__normalize_rename_fields` runs **before** those steps (it is the first thing `__normalize_mapping` calls) and lacked the guard, so `_normalize_rename` executed `'rename' in schema[field]` on the `None` rules set and raised `TypeError`.

## Fix

Raise `_SchemaRuleTypeError` in `__normalize_rename_fields` when a field's resolved rules set is `None`, mirroring the existing guards:

```python
def __normalize_rename_fields(self, mapping, schema):
    for field in tuple(mapping):
        if field in schema:
            if schema[field] is None:
                raise _SchemaRuleTypeError
            self._normalize_rename(mapping, schema, field)
            self._normalize_rename_handler(mapping, schema, field)
```

The mapping now fails validation with the correct error instead of crashing:

| Input | Before | After |
| --- | --- | --- |
| `{'list': {'type': 'error'}}` for a `list` schema | `TypeError: argument of type 'NoneType' is not iterable` | `validate() -> False`, `errors == {'list': ['must be of list type']}` |
| reporter's nested `image_thumb` case | same `TypeError` | `errors == {'metadata': [{'image_thumb': ['must be of list type']}]}` |

Valid documents, ordinary `rename`/`rename_handler` normalization, and the existing issue #250 list/dict-conflation tests are unaffected.

## Tests

Added two regression tests in `cerberus/tests/test_normalization.py` (a minimal case and the reporter's nested reproduction). Proven to guard the bug — with the source fix stashed:

```
FAILED test_mapping_for_list_schema_reports_type_error - TypeError: argument of type 'NoneType' is not iterable
FAILED test_mapping_for_nested_list_schema_reports_type_error - TypeError: ...
```

and passing with the fix restored. The `max_cache_size` guard in `test_validated_schema_cache` is bumped from 163 to 170 to account for the new schemas, exactly as that test's own message instructs ("If you added tests with new schemas, you can try to adjust the variable `max_cache_size`").

Full suite: **248 passed, 1 skipped** (246 → 248 from the two new tests), no regressions. `black --check` and `flake8` clean on the changed files.
