### PR TITLE
Fix keysrules normalization leaving the original key on a collision

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Cerberus Changelog
 ==================
 
+Unreleased
+----------
+
+Fixed
+~~~~~
+
+- Normalizing dictionary keys with ``keysrules`` no longer leaves the
+  original key behind when two keys are coerced to the same target; the
+  colliding source key is now dropped like in the non-colliding case.
+
+
 Version 1.3.8
 -------------
 

--- a/cerberus/tests/test_normalization.py
+++ b/cerberus/tests/test_normalization.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 from tempfile import NamedTemporaryFile
 
+import pytest
 from pytest import mark
 
 from cerberus import Validator, errors
@@ -270,6 +271,20 @@ def test_coerce_in_keysrules():
     document = {'thing': {'5': 'foo'}}
     expected = {'thing': {5: 'foo'}}
     assert_normalized(document, expected, schema)
+
+
+def _coerce_to_x(key):
+    return 'x'
+
+
+def test_coerce_in_keysrules_collision_drops_original_key():
+    # A colliding source key must not be left behind in the mapping.
+    schema = {'thing': {'type': 'dict', 'keysrules': {'coerce': _coerce_to_x}}}
+    document = {'thing': {'a': 1, 'b': 2}}
+    validator = Validator(schema)
+    with pytest.warns(UserWarning, match='already exists'):
+        result = validator.normalized(document)
+    assert result == {'thing': {'x': 2}}
 
 
 def test_coercion_of_sequence_items(validator):

--- a/cerberus/tests/test_schema.py
+++ b/cerberus/tests/test_schema.py
@@ -88,7 +88,7 @@ def test_validated_schema_cache():
     v = Validator({'foozifix': {'coerce': int}})
     assert len(v._valid_schemas) == cache_size
 
-    max_cache_size = 163
+    max_cache_size = 165
     assert cache_size <= max_cache_size, (
         "There's an unexpected high amount (%s) of cached valid "
         "definition schemas. Unless you added further tests, "

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -818,10 +818,10 @@ class BareValidator(object):
                         key=k,
                     )
                 )
-                mapping[field][result[k]] = mapping[field][k]
-            else:
-                mapping[field][result[k]] = mapping[field][k]
-                del mapping[field][k]
+            # The `continue` above guarantees k != result[k], so the original
+            # key must always be dropped after the rename.
+            mapping[field][result[k]] = mapping[field][k]
+            del mapping[field][k]
 
     def __normalize_mapping_per_valuesrules(self, field, mapping, value_rules):
         schema = dict(((k, value_rules) for k in mapping[field]))


### PR DESCRIPTION

## Problem

When normalizing a mapping with `keysrules` that coerces two keys to the same
target, the colliding source key is left behind in the mapping:

```python
from cerberus import Validator

def to_x(key):
    return 'x'

v = Validator({'thing': {'type': 'dict', 'keysrules': {'coerce': to_x}}})
v.normalized({'thing': {'a': 1, 'b': 2}})
# {'thing': {'b': 2, 'x': 2}}   <-- 'b' should have been renamed away
# expected: {'thing': {'x': 2}}
```

Both `a` and `b` are coerced to `x`. `a` is renamed correctly (removed), but the
second rename collides with the now-existing `x`, and `b` is left in the result
alongside `x`.

## Root cause

`cerberus/validator.py`, `__normalize_mapping_per_keysrules`:

```python
if result[k] in mapping[field]:
    warn(... "already exists, its value is replaced." ...)
    mapping[field][result[k]] = mapping[field][k]
else:
    mapping[field][result[k]] = mapping[field][k]
    del mapping[field][k]
```

The non-colliding branch deletes the original key `k` after the rename, but the
colliding branch does not, so `k` survives. The `if k == result[k]: continue`
guard just above guarantees `k != result[k]`, so the original key must always be
dropped after writing the target.

## Fix

Always assign the target and delete the original key; keep only the "already
exists" warning conditional. This makes the colliding and non-colliding paths
consistent.

## Test

`cerberus/tests/test_normalization.py::test_coerce_in_keysrules_collision_drops_original_key`
coerces two keys to the same target and asserts the result is `{'thing': {'x': 2}}`
(the colliding source key is gone). It fails on the current `1.3.x`
(`{'thing': {'b': 2, 'x': 2}}`) and passes with the fix.
