### PR TITLE
Document how nullable fields interact with coercion

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Contributors
 - Evgeny Odegov
 - Florian Rathgeber
 - Gabriel Wainer
+- Gonghan-Princess
 - Harro van der Klauw
 - Jaroslav Semančík
 - Jonathan Huot

--- a/docs/normalization-rules.rst
+++ b/docs/normalization-rules.rst
@@ -136,4 +136,33 @@ is processed through that chain of coercers.
    >>> v.document
    {'flag': True}
 
+Coercion is also applied to :obj:`None` values when ``nullable`` is ``True``.
+If the callable succeeds, its return value replaces :obj:`None`. For example,
+``str(None)`` returns the string ``'None'``. If the callable raises an exception
+for a :obj:`None` value and the field is nullable, the exception is ignored and
+the value remains :obj:`None`, as with ``int(None)``:
+
+.. doctest::
+
+   >>> v.schema = {'foo': {'type': 'string', 'nullable': True, 'coerce': str}}
+   >>> v.normalized({'foo': None})
+   {'foo': 'None'}
+   >>> v.schema = {'foo': {'type': 'integer', 'nullable': True, 'coerce': int}}
+   >>> v.normalized({'foo': None})
+   {'foo': None}
+   >>> v.errors
+   {}
+
+To preserve :obj:`None` values explicitly, use a callable that returns
+:obj:`None` unchanged:
+
+.. doctest::
+
+   >>> to_string = lambda value: str(value) if value is not None else None
+   >>> v.schema = {'foo': {'type': 'string', 'nullable': True, 'coerce': to_string}}
+   >>> v.normalized({'foo': None})
+   {'foo': None}
+   >>> v.normalized({'foo': 1})
+   {'foo': '1'}
+
 .. versionadded:: 0.9

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -238,7 +238,10 @@ It can be useful for flows like this:
                        if x is not None]
 
 If a coercion callable or method raises an exception then the exception will
-be caught and the validation with fail.
+be caught and the validation will fail, unless the value being coerced is
+:obj:`None` and the field has ``nullable`` set to ``True``. In that case, the
+value remains :obj:`None` and no coercion error is recorded (see
+:ref:`type-coercion`).
 
 .. versionadded:: 0.9
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -518,6 +518,10 @@ defaults ``False``.
    >>> v.errors
    {'an_integer': ['null value not allowed']}
 
+This rule does not prevent :ref:`type-coercion` from being applied to
+:obj:`None` values. A successful coercion can replace :obj:`None` even when
+``nullable`` is ``True``.
+
 .. versionchanged:: 0.7 ``nullable`` is valid on fields lacking type definition.
 .. versionadded:: 0.3.0
 


### PR DESCRIPTION
`nullable=True` allows a `None` value, but does not skip its coercion: `coerce=str` produces `'None'`, while a failed `int(None)` leaves `None` without a coercion error. Document this existing behavior with executable examples and a custom coercer that preserves `None`.

Link the nullable rule to the coercion explanation and qualify the usage guide's statement that coercion exceptions always fail validation. This addresses the documentation request in #427 without changing runtime behavior.

Validation (Python 3.12.10):

- `python -m pytest cerberus/tests -q`: 246 passed, 1 skipped.
- `python -m sphinx -b doctest -W --keep-going docs <output-dir>`: 295 doctests passed.
- `python -m sphinx -b html -W --keep-going docs <output-dir>`: passed.
- Verified the examples against both `normalized()` and `validated()`, including successful string coercion, ignored failure on `None`, explicit preservation, and failure on a non-`None` value.

AI assistance: OpenAI Codex helped investigate the issue, draft the documentation, and run validation. No third-party code was copied into this change.
